### PR TITLE
Fix bug in make file to add buildinfo the vitess binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ build:
 ifndef NOBANNER
 	echo $$(date): Building source tree
 endif
-	go install $(VT_GO_PARALLEL) -ldflags "$(tools/build_version_flags.sh)" ./go/...
+	go install $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/...
 
 parser:
 	make -C go/vt/sqlparser


### PR DESCRIPTION
updated build info available after this fix
```
curl -s localhost:${port}/debug/vars | grep -i Build
"BuildGitRev": "4491ce5e2924cd84f5b3e4aec9c712c97e59dc98",
"BuildHost": "build-slave-vitess1604",
"BuildTimestamp": 1496877855,
"BuildUser": "jenkinsslave",
```