### PR TITLE
Expose version number

### DIFF
--- a/go/cmd/automation_server/automation_server.go
+++ b/go/cmd/automation_server/automation_server.go
@@ -29,10 +29,6 @@ import (
 	"github.com/youtube/vitess/go/vt/servenv"
 )
 
-var (
-	version = flag.Bool("version", false, "print binary version")
-)
-
 func init() {
 	servenv.RegisterDefaultFlags()
 }
@@ -41,7 +37,7 @@ func main() {
 
 	flag.Parse()
 
-	if *version {
+	if *servenv.Version {
 		servenv.AppVersion.Print()
 		os.Exit(0)
 	}

--- a/go/cmd/automation_server/automation_server.go
+++ b/go/cmd/automation_server/automation_server.go
@@ -29,13 +29,25 @@ import (
 	"github.com/youtube/vitess/go/vt/servenv"
 )
 
+var (
+	version = flag.Bool("version", false, "print binary version")
+)
+
 func init() {
 	servenv.RegisterDefaultFlags()
 }
 
 func main() {
+
 	flag.Parse()
+
+	if *version {
+		servenv.AppVersion.Print()
+		os.Exit(0)
+	}
+
 	fmt.Println("Automation Server, listening on:", *servenv.Port)
+
 	if *servenv.Port == 0 {
 		fmt.Println("No port specified using --port.")
 		os.Exit(1)

--- a/go/cmd/l2vtgate/main.go
+++ b/go/cmd/l2vtgate/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"math/rand"
+	"os"
 	"strings"
 	"time"
 

--- a/go/cmd/l2vtgate/main.go
+++ b/go/cmd/l2vtgate/main.go
@@ -60,7 +60,7 @@ func main() {
 
 	if *servenv.Version {
 		servenv.AppVersion.Print()
-		exit.Return(0)
+		os.Exit(0)
 	}
 
 	ts := topo.Open()

--- a/go/cmd/l2vtgate/main.go
+++ b/go/cmd/l2vtgate/main.go
@@ -42,7 +42,6 @@ var (
 	healthCheckRetryDelay  = flag.Duration("healthcheck_retry_delay", 2*time.Millisecond, "health check retry delay")
 	healthCheckTimeout     = flag.Duration("healthcheck_timeout", time.Minute, "the health check timeout period")
 	tabletTypesToWait      = flag.String("tablet_types_to_wait", "", "wait till connected for specified tablet types during Gateway initialization")
-	version                = flag.Bool("version", false, "print binary version")
 )
 
 var resilientSrvTopoServer *vtgate.ResilientSrvTopoServer
@@ -59,7 +58,7 @@ func main() {
 	flag.Parse()
 	servenv.Init()
 
-	if *version {
+	if *servenv.Version {
 		servenv.AppVersion.Print()
 		exit.Return(0)
 	}

--- a/go/cmd/l2vtgate/main.go
+++ b/go/cmd/l2vtgate/main.go
@@ -42,6 +42,7 @@ var (
 	healthCheckRetryDelay  = flag.Duration("healthcheck_retry_delay", 2*time.Millisecond, "health check retry delay")
 	healthCheckTimeout     = flag.Duration("healthcheck_timeout", time.Minute, "the health check timeout period")
 	tabletTypesToWait      = flag.String("tablet_types_to_wait", "", "wait till connected for specified tablet types during Gateway initialization")
+	version                = flag.Bool("version", false, "print binary version")
 )
 
 var resilientSrvTopoServer *vtgate.ResilientSrvTopoServer
@@ -57,6 +58,11 @@ func main() {
 
 	flag.Parse()
 	servenv.Init()
+
+	if *version {
+		servenv.AppVersion.Print()
+		exit.Return(0)
+	}
 
 	ts := topo.Open()
 	defer ts.Close()

--- a/go/cmd/mysqlctld/mysqlctld.go
+++ b/go/cmd/mysqlctld/mysqlctld.go
@@ -44,6 +44,8 @@ var (
 	// mysqlctl init flags
 	waitTime      = flag.Duration("wait_time", 5*time.Minute, "how long to wait for mysqld startup or shutdown")
 	initDBSQLFile = flag.String("init_db_sql_file", "", "path to .sql file to run after mysql_install_db")
+
+	version = flag.Bool("version", false, "print binary version")
 )
 
 func init() {
@@ -59,6 +61,11 @@ func main() {
 	dbconfigFlags := dbconfigs.DbaConfig
 	dbconfigs.RegisterFlags(dbconfigFlags)
 	flag.Parse()
+
+	if *version {
+		servenv.AppVersion.Print()
+		exit.Return(0)
+	}
 
 	// We'll register this OnTerm handler before mysqld starts, so we get notified
 	// if mysqld dies on its own without us (or our RPC client) telling it to.

--- a/go/cmd/mysqlctld/mysqlctld.go
+++ b/go/cmd/mysqlctld/mysqlctld.go
@@ -62,7 +62,7 @@ func main() {
 
 	if *servenv.Version {
 		servenv.AppVersion.Print()
-		exit.Return(0)
+		os.Exit(0)
 	}
 
 	// We'll register this OnTerm handler before mysqld starts, so we get notified

--- a/go/cmd/mysqlctld/mysqlctld.go
+++ b/go/cmd/mysqlctld/mysqlctld.go
@@ -44,8 +44,6 @@ var (
 	// mysqlctl init flags
 	waitTime      = flag.Duration("wait_time", 5*time.Minute, "how long to wait for mysqld startup or shutdown")
 	initDBSQLFile = flag.String("init_db_sql_file", "", "path to .sql file to run after mysql_install_db")
-
-	version = flag.Bool("version", false, "print binary version")
 )
 
 func init() {
@@ -62,7 +60,7 @@ func main() {
 	dbconfigs.RegisterFlags(dbconfigFlags)
 	flag.Parse()
 
-	if *version {
+	if *servenv.Version {
 		servenv.AppVersion.Print()
 		exit.Return(0)
 	}

--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -50,8 +50,6 @@ var (
 
 	schemaDir = flag.String("schema_dir", "", "Schema base directory. Should contain one directory per keyspace, with a vschema.json file if necessary.")
 
-	version = flag.Bool("version", false, "print binary version")
-
 	ts topo.Server
 )
 
@@ -69,7 +67,7 @@ func main() {
 	mysqlctl.RegisterFlags()
 	flag.Parse()
 
-	if *version {
+	if *servenv.Version {
 		servenv.AppVersion.Print()
 		exit.Return(0)
 	}

--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -23,6 +23,7 @@ package main
 
 import (
 	"flag"
+	"os"
 	"strings"
 	"time"
 

--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -50,6 +50,8 @@ var (
 
 	schemaDir = flag.String("schema_dir", "", "Schema base directory. Should contain one directory per keyspace, with a vschema.json file if necessary.")
 
+	version = flag.Bool("version", false, "print binary version")
+
 	ts topo.Server
 )
 
@@ -66,6 +68,12 @@ func main() {
 	dbconfigs.RegisterFlags(dbconfigFlags)
 	mysqlctl.RegisterFlags()
 	flag.Parse()
+
+	if *version {
+		servenv.AppVersion.Print()
+		exit.Return(0)
+	}
+
 	if len(flag.Args()) > 0 {
 		flag.Usage()
 		log.Errorf("vtcombo doesn't take any positional arguments")

--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -69,7 +69,7 @@ func main() {
 
 	if *servenv.Version {
 		servenv.AppVersion.Print()
-		exit.Return(0)
+		os.Exit(0)
 	}
 
 	if len(flag.Args()) > 0 {

--- a/go/cmd/vtctl/vtctl.go
+++ b/go/cmd/vtctl/vtctl.go
@@ -39,7 +39,6 @@ import (
 
 var (
 	waitTime = flag.Duration("wait-time", 24*time.Hour, "time to wait on an action")
-	version  = flag.Bool("version", false, "print binary version")
 )
 
 func init() {
@@ -72,7 +71,7 @@ func main() {
 	flag.Parse()
 	args := flag.Args()
 
-	if *version {
+	if *servenv.Version {
 		servenv.AppVersion.Print()
 		exit.Return(0)
 	}

--- a/go/cmd/vtctl/vtctl.go
+++ b/go/cmd/vtctl/vtctl.go
@@ -73,7 +73,7 @@ func main() {
 
 	if *servenv.Version {
 		servenv.AppVersion.Print()
-		exit.Return(0)
+		os.Exit(0)
 	}
 
 	if len(args) == 0 {

--- a/go/cmd/vtctl/vtctl.go
+++ b/go/cmd/vtctl/vtctl.go
@@ -39,6 +39,7 @@ import (
 
 var (
 	waitTime = flag.Duration("wait-time", 24*time.Hour, "time to wait on an action")
+	version  = flag.Bool("version", false, "print binary version")
 )
 
 func init() {
@@ -70,10 +71,17 @@ func main() {
 
 	flag.Parse()
 	args := flag.Args()
+
+	if *version {
+		servenv.AppVersion.Print()
+		exit.Return(0)
+	}
+
 	if len(args) == 0 {
 		flag.Usage()
 		exit.Return(1)
 	}
+
 	action := args[0]
 
 	startMsg := fmt.Sprintf("USER=%v SUDO_USER=%v %v", os.Getenv("USER"), os.Getenv("SUDO_USER"), strings.Join(os.Args, " "))

--- a/go/cmd/vtctld/main.go
+++ b/go/cmd/vtctld/main.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"flag"
-	"github.com/youtube/vitess/go/exit"
+
 	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/vtctld"
@@ -40,7 +40,7 @@ func main() {
 
 	if *servenv.Version {
 		servenv.AppVersion.Print()
-		exit.Return(0)
+		os.Exit(0)
 	}
 
 	ts = topo.Open()

--- a/go/cmd/vtctld/main.go
+++ b/go/cmd/vtctld/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"os"
 
 	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/topo"

--- a/go/cmd/vtctld/main.go
+++ b/go/cmd/vtctld/main.go
@@ -30,8 +30,7 @@ func init() {
 
 // used at runtime by plug-ins
 var (
-	ts      topo.Server
-	version = flag.Bool("version", false, "print binary version")
+	ts topo.Server
 )
 
 func main() {
@@ -39,7 +38,7 @@ func main() {
 	servenv.Init()
 	defer servenv.Close()
 
-	if *version {
+	if *servenv.Version {
 		servenv.AppVersion.Print()
 		exit.Return(0)
 	}

--- a/go/cmd/vtctld/main.go
+++ b/go/cmd/vtctld/main.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"flag"
-
+	"github.com/youtube/vitess/go/exit"
 	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/vtctld"
@@ -30,13 +30,19 @@ func init() {
 
 // used at runtime by plug-ins
 var (
-	ts topo.Server
+	ts      topo.Server
+	version = flag.Bool("version", false, "print binary version")
 )
 
 func main() {
 	flag.Parse()
 	servenv.Init()
 	defer servenv.Close()
+
+	if *version {
+		servenv.AppVersion.Print()
+		exit.Return(0)
+	}
 
 	ts = topo.Open()
 	defer ts.Close()

--- a/go/cmd/vtgate/vtgate.go
+++ b/go/cmd/vtgate/vtgate.go
@@ -63,7 +63,7 @@ func main() {
 
 	if *servenv.Version {
 		servenv.AppVersion.Print()
-		exit.Return(0)
+		os.Exit(0)
 	}
 
 	if initFakeZK != nil {

--- a/go/cmd/vtgate/vtgate.go
+++ b/go/cmd/vtgate/vtgate.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"math/rand"
+	"os"
 	"strings"
 	"time"
 

--- a/go/cmd/vtgate/vtgate.go
+++ b/go/cmd/vtgate/vtgate.go
@@ -43,6 +43,7 @@ var (
 	healthCheckRetryDelay  = flag.Duration("healthcheck_retry_delay", 2*time.Millisecond, "health check retry delay")
 	healthCheckTimeout     = flag.Duration("healthcheck_timeout", time.Minute, "the health check timeout period")
 	tabletTypesToWait      = flag.String("tablet_types_to_wait", "", "wait till connected for specified tablet types during Gateway initialization")
+	version                = flag.Bool("version", false, "print binary version")
 )
 
 var resilientSrvTopoServer *vtgate.ResilientSrvTopoServer
@@ -60,6 +61,11 @@ func main() {
 
 	flag.Parse()
 	servenv.Init()
+
+	if *version {
+		servenv.AppVersion.Print()
+		exit.Return(0)
+	}
 
 	if initFakeZK != nil {
 		initFakeZK()

--- a/go/cmd/vtgate/vtgate.go
+++ b/go/cmd/vtgate/vtgate.go
@@ -43,7 +43,6 @@ var (
 	healthCheckRetryDelay  = flag.Duration("healthcheck_retry_delay", 2*time.Millisecond, "health check retry delay")
 	healthCheckTimeout     = flag.Duration("healthcheck_timeout", time.Minute, "the health check timeout period")
 	tabletTypesToWait      = flag.String("tablet_types_to_wait", "", "wait till connected for specified tablet types during Gateway initialization")
-	version                = flag.Bool("version", false, "print binary version")
 )
 
 var resilientSrvTopoServer *vtgate.ResilientSrvTopoServer
@@ -62,7 +61,7 @@ func main() {
 	flag.Parse()
 	servenv.Init()
 
-	if *version {
+	if *servenv.Version {
 		servenv.AppVersion.Print()
 		exit.Return(0)
 	}

--- a/go/cmd/vtgateclienttest/main.go
+++ b/go/cmd/vtgateclienttest/main.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"flag"
+	"os"
 
 	"github.com/youtube/vitess/go/cmd/vtgateclienttest/services"
 	"github.com/youtube/vitess/go/exit"

--- a/go/cmd/vtgateclienttest/main.go
+++ b/go/cmd/vtgateclienttest/main.go
@@ -28,6 +28,10 @@ import (
 	"github.com/youtube/vitess/go/vt/vtgate"
 )
 
+var (
+	version = flag.Bool("version", false, "print binary version")
+)
+
 func init() {
 	servenv.RegisterDefaultFlags()
 }
@@ -37,6 +41,11 @@ func main() {
 
 	flag.Parse()
 	servenv.Init()
+
+	if *version {
+		servenv.AppVersion.Print()
+		exit.Return(0)
+	}
 
 	// The implementation chain.
 	servenv.OnRun(func() {

--- a/go/cmd/vtgateclienttest/main.go
+++ b/go/cmd/vtgateclienttest/main.go
@@ -40,7 +40,7 @@ func main() {
 
 	if *servenv.Version {
 		servenv.AppVersion.Print()
-		exit.Return(0)
+		os.Exit(0)
 	}
 
 	// The implementation chain.

--- a/go/cmd/vtgateclienttest/main.go
+++ b/go/cmd/vtgateclienttest/main.go
@@ -28,10 +28,6 @@ import (
 	"github.com/youtube/vitess/go/vt/vtgate"
 )
 
-var (
-	version = flag.Bool("version", false, "print binary version")
-)
-
 func init() {
 	servenv.RegisterDefaultFlags()
 }
@@ -42,7 +38,7 @@ func main() {
 	flag.Parse()
 	servenv.Init()
 
-	if *version {
+	if *servenv.Version {
 		servenv.AppVersion.Print()
 		exit.Return(0)
 	}

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 
 	log "github.com/golang/glog"
+	"github.com/youtube/vitess/go/exit"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/mysqlctl"
 	"github.com/youtube/vitess/go/vt/servenv"
@@ -39,6 +40,8 @@ var (
 	tableACLConfig        = flag.String("table-acl-config", "", "path to table access checker config file")
 	tabletPath            = flag.String("tablet-path", "", "tablet alias")
 
+	version = flag.Bool("version", false, "print binary version")
+
 	agent *tabletmanager.ActionAgent
 )
 
@@ -52,6 +55,12 @@ func main() {
 	dbconfigs.RegisterFlags(dbconfigFlags)
 	mysqlctl.RegisterFlags()
 	flag.Parse()
+
+	if *version {
+		servenv.AppVersion.Print()
+		exit.Return(0)
+	}
+
 	if len(flag.Args()) > 0 {
 		flag.Usage()
 		log.Exit("vttablet doesn't take any positional arguments")

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -40,8 +40,6 @@ var (
 	tableACLConfig        = flag.String("table-acl-config", "", "path to table access checker config file")
 	tabletPath            = flag.String("tablet-path", "", "tablet alias")
 
-	version = flag.Bool("version", false, "print binary version")
-
 	agent *tabletmanager.ActionAgent
 )
 
@@ -56,7 +54,7 @@ func main() {
 	mysqlctl.RegisterFlags()
 	flag.Parse()
 
-	if *version {
+	if *servenv.Version {
 		servenv.AppVersion.Print()
 		exit.Return(0)
 	}

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 
 	log "github.com/golang/glog"
-	"github.com/youtube/vitess/go/exit"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/mysqlctl"
 	"github.com/youtube/vitess/go/vt/servenv"
@@ -56,7 +55,7 @@ func main() {
 
 	if *servenv.Version {
 		servenv.AppVersion.Print()
-		exit.Return(0)
+		os.Exit(0)
 	}
 
 	if len(flag.Args()) > 0 {

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"flag"
+	"os"
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/vt/dbconfigs"

--- a/go/cmd/vtworker/vtworker.go
+++ b/go/cmd/vtworker/vtworker.go
@@ -41,7 +41,6 @@ import (
 var (
 	cell                   = flag.String("cell", "", "cell to pick servers from")
 	commandDisplayInterval = flag.Duration("command_display_interval", time.Second, "Interval between each status update when vtworker is executing a single command from the command line")
-	version                = flag.Bool("version", false, "print binary version")
 )
 
 func init() {
@@ -71,7 +70,7 @@ func main() {
 	servenv.Init()
 	defer servenv.Close()
 
-	if *version {
+	if *servenv.Version {
 		servenv.AppVersion.Print()
 		exit.Return(0)
 	}

--- a/go/cmd/vtworker/vtworker.go
+++ b/go/cmd/vtworker/vtworker.go
@@ -41,6 +41,7 @@ import (
 var (
 	cell                   = flag.String("cell", "", "cell to pick servers from")
 	commandDisplayInterval = flag.Duration("command_display_interval", time.Second, "Interval between each status update when vtworker is executing a single command from the command line")
+	version                = flag.Bool("version", false, "print binary version")
 )
 
 func init() {
@@ -69,6 +70,11 @@ func main() {
 
 	servenv.Init()
 	defer servenv.Close()
+
+	if *version {
+		servenv.AppVersion.Print()
+		exit.Return(0)
+	}
 
 	ts := topo.Open()
 	defer ts.Close()

--- a/go/cmd/vtworker/vtworker.go
+++ b/go/cmd/vtworker/vtworker.go
@@ -72,7 +72,7 @@ func main() {
 
 	if *servenv.Version {
 		servenv.AppVersion.Print()
-		exit.Return(0)
+		os.Exit(0)
 	}
 
 	ts := topo.Open()

--- a/go/vt/servenv/buildinfo.go
+++ b/go/vt/servenv/buildinfo.go
@@ -18,9 +18,9 @@ package servenv
 
 import (
 	"fmt"
-	"time"
-
 	"github.com/youtube/vitess/go/stats"
+	"runtime"
+	"time"
 )
 
 var (
@@ -30,13 +30,46 @@ var (
 	buildGitRev = ""
 )
 
+var AppVersion versionInfo
+
+type versionInfo struct {
+	buildHost       string
+	buildUser       string
+	buildTime       int64
+	buildTimePretty string
+	buildGitRev     string
+	goVersion       string
+	goOS            string
+	goArch          string
+}
+
+func (v *versionInfo) Print() {
+	fmt.Printf("Version: %s built on %s by %s@%s using %s %s/%s\n", v.buildGitRev, v.buildTimePretty, v.buildUser, v.buildHost, v.goVersion, v.goOS, v.goArch)
+}
+
 func init() {
 	t, err := time.Parse(time.UnixDate, buildTime)
 	if buildTime != "" && err != nil {
 		panic(fmt.Sprintf("Couldn't parse build timestamp %q: %v", buildTime, err))
 	}
-	stats.NewString("BuildHost").Set(buildHost)
-	stats.NewString("BuildUser").Set(buildUser)
-	stats.NewInt("BuildTimestamp").Set(t.Unix())
-	stats.NewString("BuildGitRev").Set(buildGitRev)
+
+	AppVersion = versionInfo{
+		buildHost:       buildHost,
+		buildUser:       buildUser,
+		buildTime:       t.Unix(),
+		buildTimePretty: buildTime,
+		buildGitRev:     buildGitRev,
+		goVersion:       runtime.Version(),
+		goOS:            runtime.GOOS,
+		goArch:          runtime.GOARCH,
+	}
+
+	stats.NewString("BuildHost").Set(AppVersion.buildHost)
+	stats.NewString("BuildUser").Set(AppVersion.buildUser)
+	stats.NewInt("BuildTimestamp").Set(AppVersion.buildTime)
+	stats.NewString("BuildGitRev").Set(AppVersion.buildGitRev)
+	stats.NewString("GoVersion").Set(AppVersion.goVersion)
+	stats.NewString("GoOS").Set(AppVersion.goOS)
+	stats.NewString("GoArch").Set(AppVersion.goArch)
+
 }

--- a/go/vt/servenv/buildinfo.go
+++ b/go/vt/servenv/buildinfo.go
@@ -17,6 +17,7 @@ limitations under the License.
 package servenv
 
 import (
+	"flag"
 	"fmt"
 	"github.com/youtube/vitess/go/stats"
 	"runtime"
@@ -28,6 +29,7 @@ var (
 	buildUser   = ""
 	buildTime   = ""
 	buildGitRev = ""
+	Version     = flag.Bool("version", false, "print binary version")
 )
 
 var AppVersion versionInfo

--- a/go/vt/servenv/buildinfo.go
+++ b/go/vt/servenv/buildinfo.go
@@ -19,9 +19,10 @@ package servenv
 import (
 	"flag"
 	"fmt"
-	"github.com/youtube/vitess/go/stats"
 	"runtime"
 	"time"
+
+	"github.com/youtube/vitess/go/stats"
 )
 
 var (


### PR DESCRIPTION
This PR expose some build informations like git hash, build time, go version/OS/architecture etc. via the stats API and the new CLI flag `version`. 

```
$ ./vtctl -version
Version: a78c18da1fbb913a6f630667028d4c9ab713e66a built on Tue Jun 13 05:41:49 PDT 2017 by jenkinsslave@build-slave-vitess1604 using go1.8.3 linux/amd64
```