### PR TITLE
make grpc max message size options apply to the client as well

### DIFF
--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -53,10 +53,6 @@ var (
 	// GRPCCA is the CA to use if TLS is enabled
 	GRPCCA *string
 
-	// GRPCMaxMessageSize is the maximum message size which the gRPC server will
-	// accept. Larger messages will be rejected.
-	GRPCMaxMessageSize *int
-
 	// GRPCServer is the global server to serve gRPC.
 	GRPCServer *grpc.Server
 )
@@ -102,9 +98,10 @@ func createGRPCServer() {
 	// grpc: received message length XXXXXXX exceeding the max size 4194304
 	// Note: For gRPC 1.0.0 it's sufficient to set the limit on the server only
 	// because it's not enforced on the client side.
-	if GRPCMaxMessageSize != nil {
-		opts = append(opts, grpc.MaxRecvMsgSize(*GRPCMaxMessageSize))
-		opts = append(opts, grpc.MaxSendMsgSize(*GRPCMaxMessageSize))
+	if grpcutils.MaxMessageSize != nil {
+		log.Infof("Setting grpc max message size to %d", *grpcutils.MaxMessageSize)
+		opts = append(opts, grpc.MaxRecvMsgSize(*grpcutils.MaxMessageSize))
+		opts = append(opts, grpc.MaxSendMsgSize(*grpcutils.MaxMessageSize))
 	}
 
 	GRPCServer = grpc.NewServer(opts...)
@@ -133,9 +130,8 @@ func RegisterGRPCFlags() {
 	GRPCCert = flag.String("grpc_cert", "", "certificate to use, requires grpc_key, enables TLS")
 	GRPCKey = flag.String("grpc_key", "", "key to use, requires grpc_cert, enables TLS")
 	GRPCCA = flag.String("grpc_ca", "", "ca to use, requires TLS, and enforces client cert check")
-	// Note: We're using 4 MiB as default value because that's the default in the
-	// gRPC 1.0.0 Go server.
-	GRPCMaxMessageSize = flag.Int("grpc_max_message_size", 4*1024*1024, "Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'.")
+
+	grpcutils.RegisterFlags();
 }
 
 // GRPCCheckServiceMap returns if we should register a gRPC service

--- a/go/vt/servenv/grpcutils/options.go
+++ b/go/vt/servenv/grpcutils/options.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpcutils
+
+import (
+	"flag"
+)
+
+var (
+	defaultMaxMessageSize = 4*1024*1024
+	// MaxMessageSize is the maximum message size which the gRPC server will
+	// accept. Larger messages will be rejected.
+	MaxMessageSize *int = &defaultMaxMessageSize
+)
+
+func RegisterFlags(){
+	// Note: We're using 4 MiB as default value because that's the default in the
+	// gRPC 1.0.0 Go server.
+	MaxMessageSize = flag.Int("grpc_max_message_size", defaultMaxMessageSize, "Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'.")
+}

--- a/go/vt/vtgate/grpcvtgateconn/conn.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn.go
@@ -59,7 +59,7 @@ func dial(ctx context.Context, addr string, timeout time.Duration) (vtgateconn.I
 	if err != nil {
 		return nil, err
 	}
-	cc, err := grpc.Dial(addr, opt, grpc.WithBlock(), grpc.WithTimeout(timeout))
+	cc, err := grpc.Dial(addr, opt, grpc.WithBlock(), grpc.WithTimeout(timeout), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(*grpcutils.MaxMessageSize), grpc.MaxCallSendMsgSize(*grpcutils.MaxMessageSize)))
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vttablet/grpctabletconn/conn.go
+++ b/go/vt/vttablet/grpctabletconn/conn.go
@@ -78,6 +78,7 @@ func DialTablet(tablet *topodatapb.Tablet, timeout time.Duration) (queryservice.
 	if timeout > 0 {
 		opts = append(opts, grpc.WithBlock(), grpc.WithTimeout(timeout))
 	}
+	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(*grpcutils.MaxMessageSize), grpc.MaxCallSendMsgSize(*grpcutils.MaxMessageSize)))
 	cc, err := grpc.Dial(addr, opts...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
For both vttablet and vtgate, add  options to the grpc.Dial call site
that pass through the max message size option and thereby override
the 4MB default.

*Slack Specific*:
Will add tests and propose upstream as well but this should fix the issues.

