### PR TITLE
Pin Travis test config to Ubuntu Precise.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+# TODO(mberlin): Travis will break this configuration on Sep 5, 2017.
+# Moving off the container based infrastructure (sudo: required) may buy us more time.
+# But we should move to Docker based tests eventually.
+# See their announcement: https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming
+dist: precise
 # Use container-based infrastructure (see: http://docs.travis-ci.com/user/workers/container-based-infrastructure/).
 sudo: false
 language: go


### PR DESCRIPTION
Travis CI is in the process of changing all images from Precise to Trusty.

See their announcement: https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming

This would break how we install our dependencies.

Note that we're using the Container based infrastructure (sudo: false). They plan to get rid of this combination (Precise + sudo: false) by Sep 5. Before that, we should try "sudo: required" or do the planned longterm change to run the tests within Docker images.