### PR TITLE
Fix for travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+# TODO(mberlin): Travis will break this configuration on Sep 5, 2017.
+# Moving off the container based infrastructure (sudo: required) may buy us more time.
+# But we should move to Docker based tests eventually.
+# See their announcement: https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming
+dist: precise
 # Use container-based infrastructure (see: http://docs.travis-ci.com/user/workers/container-based-infrastructure/).
 sudo: false
 language: go

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 language: go
 go:
   - 1.8
+go_import_path: github.com/youtube/vitess
 addons:
   apt:
     sources:


### PR DESCRIPTION
* Set go_import_path so forks of the project can benefit from Travis CI. Without
this change there are some assumptions in the bootstrap [script](https://github.com/rafael/vitess/blob/master/dev.env#L24) and also in the
import of packages that won't be hold in a fork of the project and the tests
will break.
* [go_import_path](https://docs.travis-ci.com/user/languages/go/) feature from travis solves this problem.