### PR TITLE
Refresh MySQL config after a backup

### DIFF
--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -321,6 +321,11 @@ func backup(ctx context.Context, mysqld MysqlDaemon, logger logutil.Logger, bh b
 	usable := backupErr == nil
 
 	// Try to restart mysqld
+	err = mysqld.RefreshConfig()
+	if err != nil {
+		return usable, fmt.Errorf("can't refresh mysqld config: %v", err)
+	}
+
 	err = mysqld.Start(ctx)
 	if err != nil {
 		return usable, fmt.Errorf("can't restart mysqld: %v", err)

--- a/go/vt/mysqlctl/mysql_daemon.go
+++ b/go/vt/mysqlctl/mysql_daemon.go
@@ -46,6 +46,7 @@ type MysqlDaemon interface {
 	Shutdown(ctx context.Context, waitForMysqld bool) error
 	RunMysqlUpgrade() error
 	ReinitConfig(ctx context.Context) error
+	RefreshConfig() error
 	Wait(ctx context.Context) error
 
 	// GetMysqlPort returns the current port mysql is listening on.
@@ -260,6 +261,11 @@ func (fmd *FakeMysqlDaemon) RunMysqlUpgrade() error {
 
 // ReinitConfig is part of the MysqlDaemon interface
 func (fmd *FakeMysqlDaemon) ReinitConfig(ctx context.Context) error {
+	return nil
+}
+
+// RefreshConfig is part of the MysqlDaemon interface
+func (fmd *FakeMysqlDaemon) RefreshConfig() error {
 	return nil
 }
 

--- a/test/tablet.py
+++ b/test/tablet.py
@@ -564,15 +564,13 @@ class Tablet(object):
     if supports_backups:
       args.extend(['-restore_from_backup'] + get_backup_storage_flags())
 
-      # When vttablet restores from backup, and if not using
-      # mysqlctld, it will re-generate the .cnf file.  So we need to
+      # When vttablet restores from backup, it will re-generate the .cnf file.  So we need to
       # have EXTRA_MY_CNF set properly.
-      if not self.use_mysqlctld:
-        all_extra_my_cnf = get_all_extra_my_cnf(None)
-        if all_extra_my_cnf:
-          if not extra_env:
-            extra_env = {}
-          extra_env['EXTRA_MY_CNF'] = ':'.join(all_extra_my_cnf)
+      all_extra_my_cnf = get_all_extra_my_cnf(None)
+      if all_extra_my_cnf:
+        if not extra_env:
+          extra_env = {}
+        extra_env['EXTRA_MY_CNF'] = ':'.join(all_extra_my_cnf)
 
     if extra_args:
       args.extend(extra_args)


### PR DESCRIPTION
# Description

* This should address this issue https://github.com/youtube/vitess/issues/2908
* This commit refreshes mysql config after a backup. In this case, if there were config changes after stopping the mysql daemon, restart after the backup will have these changes.

# Tests

* Tested locally.
