### PR TITLE
slack merge upstream 2017 08 21

### DIFF
--- a/go/vt/servenv/grpcutils/options.go
+++ b/go/vt/servenv/grpcutils/options.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpcutils
+
+import (
+	"flag"
+)
+
+var (
+	defaultMaxMessageSize = 4 * 1024 * 1024
+	// MaxMessageSize is the maximum message size which the gRPC server will
+	// accept. Larger messages will be rejected.
+	MaxMessageSize = &defaultMaxMessageSize
+)
+
+// RegisterFlags registers the command line flags for common grpc options
+func RegisterFlags() {
+	// Note: We're using 4 MiB as default value because that's the default in the
+	// gRPC 1.0.0 Go server.
+	MaxMessageSize = flag.Int("grpc_max_message_size", defaultMaxMessageSize, "Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'.")
+}

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -346,7 +346,7 @@ func TestInsertSharded(t *testing.T) {
 		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
 	}
 	wantQueries = []*querypb.BoundQuery{{
-		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0)",
+		Sql: "insert ignore into name_user_map(name, user_id) values (:name0, :user_id0)",
 		BindVariables: map[string]*querypb.BindVariable{
 			"name0":    sqltypes.BytesBindVariable([]byte("myname")),
 			"user_id0": sqltypes.Uint64BindVariable(1),
@@ -377,7 +377,7 @@ func TestInsertSharded(t *testing.T) {
 		t.Errorf("sbc1.Queries: %+v, want nil\n", sbc1.Queries)
 	}
 	wantQueries = []*querypb.BoundQuery{{
-		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0)",
+		Sql: "insert ignore into name_user_map(name, user_id) values (:name0, :user_id0)",
 		BindVariables: map[string]*querypb.BindVariable{
 			"name0":    sqltypes.BytesBindVariable([]byte("myname2")),
 			"user_id0": sqltypes.Uint64BindVariable(3),
@@ -410,7 +410,7 @@ func TestInsertComments(t *testing.T) {
 		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
 	}
 	wantQueries = []*querypb.BoundQuery{{
-		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0) /* trailing */",
+		Sql: "insert ignore into name_user_map(name, user_id) values (:name0, :user_id0) /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{
 			"name0":    sqltypes.BytesBindVariable([]byte("myname")),
 			"user_id0": sqltypes.Uint64BindVariable(1),
@@ -450,7 +450,7 @@ func TestInsertGeneratorSharded(t *testing.T) {
 		Sql:           "select next :n values from user_seq",
 		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(1)},
 	}, {
-		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0)",
+		Sql: "insert ignore into name_user_map(name, user_id) values (:name0, :user_id0)",
 		BindVariables: map[string]*querypb.BindVariable{
 			"name0":    sqltypes.BytesBindVariable([]byte("myname")),
 			"user_id0": sqltypes.Uint64BindVariable(1),
@@ -570,7 +570,7 @@ func TestInsertLookupOwned(t *testing.T) {
 		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc.Queries, wantQueries)
 	}
 	wantQueries = []*querypb.BoundQuery{{
-		Sql: "insert into music_user_map(music_id, user_id) values (:music_id0, :user_id0)",
+		Sql: "insert ignore into music_user_map(music_id, user_id) values (:music_id0, :user_id0)",
 		BindVariables: map[string]*querypb.BindVariable{
 			"music_id0": sqltypes.Int64BindVariable(3),
 			"user_id0":  sqltypes.Uint64BindVariable(2),
@@ -610,7 +610,7 @@ func TestInsertLookupOwnedGenerator(t *testing.T) {
 		Sql:           "select next :n values from user_seq",
 		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(1)},
 	}, {
-		Sql: "insert into music_user_map(music_id, user_id) values (:music_id0, :user_id0)",
+		Sql: "insert ignore into music_user_map(music_id, user_id) values (:music_id0, :user_id0)",
 		BindVariables: map[string]*querypb.BindVariable{
 			"music_id0": sqltypes.Int64BindVariable(4),
 			"user_id0":  sqltypes.Uint64BindVariable(2),
@@ -879,7 +879,7 @@ func TestMultiInsertSharded(t *testing.T) {
 	}
 
 	wantQueries1 = []*querypb.BoundQuery{{
-		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0), (:name1, :user_id1)",
+		Sql: "insert ignore into name_user_map(name, user_id) values (:name0, :user_id0), (:name1, :user_id1)",
 		BindVariables: map[string]*querypb.BindVariable{
 			"name0":    sqltypes.BytesBindVariable([]byte("myname1")),
 			"user_id0": sqltypes.Uint64BindVariable(1),
@@ -917,7 +917,7 @@ func TestMultiInsertSharded(t *testing.T) {
 		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
 	}
 	wantQueries = []*querypb.BoundQuery{{
-		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0), (:name1, :user_id1)",
+		Sql: "insert ignore into name_user_map(name, user_id) values (:name0, :user_id0), (:name1, :user_id1)",
 		BindVariables: map[string]*querypb.BindVariable{
 			"name0":    sqltypes.BytesBindVariable([]byte("myname1")),
 			"user_id0": sqltypes.Uint64BindVariable(1),
@@ -963,7 +963,7 @@ func TestMultiInsertGenerator(t *testing.T) {
 		Sql:           "select next :n values from user_seq",
 		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(2)},
 	}, {
-		Sql: "insert into music_user_map(music_id, user_id) values (:music_id0, :user_id0), (:music_id1, :user_id1)",
+		Sql: "insert ignore into music_user_map(music_id, user_id) values (:music_id0, :user_id0), (:music_id1, :user_id1)",
 		BindVariables: map[string]*querypb.BindVariable{
 			"user_id0":  sqltypes.Uint64BindVariable(2),
 			"music_id0": sqltypes.Int64BindVariable(1),
@@ -1017,7 +1017,7 @@ func TestMultiInsertGeneratorSparse(t *testing.T) {
 		Sql:           "select next :n values from user_seq",
 		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(2)},
 	}, {
-		Sql: "insert into music_user_map(music_id, user_id) values (:music_id0, :user_id0), (:music_id1, :user_id1), (:music_id2, :user_id2)",
+		Sql: "insert ignore into music_user_map(music_id, user_id) values (:music_id0, :user_id0), (:music_id1, :user_id1), (:music_id2, :user_id2)",
 		BindVariables: map[string]*querypb.BindVariable{
 			"user_id0":  sqltypes.Uint64BindVariable(2),
 			"music_id0": sqltypes.Int64BindVariable(1),

--- a/go/vt/vtgate/grpcvtgateconn/conn.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn.go
@@ -58,7 +58,7 @@ func dial(ctx context.Context, addr string, timeout time.Duration) (vtgateconn.I
 	if err != nil {
 		return nil, err
 	}
-	cc, err := grpc.Dial(addr, opt, grpc.WithBlock(), grpc.WithTimeout(timeout))
+	cc, err := grpc.Dial(addr, opt, grpc.WithBlock(), grpc.WithTimeout(timeout), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(*grpcutils.MaxMessageSize), grpc.MaxCallSendMsgSize(*grpcutils.MaxMessageSize)))
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/vindexes/lookup_hash_test.go
+++ b/go/vt/vtgate/vindexes/lookup_hash_test.go
@@ -137,7 +137,7 @@ func TestLookupHashCreate(t *testing.T) {
 		t.Error(err)
 	}
 	wantQuery := &querypb.BoundQuery{
-		Sql: "insert into t(fromc,toc) values(:fromc0,:toc0)",
+		Sql: "insert ignore into t(fromc,toc) values(:fromc0,:toc0)",
 		BindVariables: map[string]*querypb.BindVariable{
 			"fromc0": sqltypes.Int64BindVariable(1),
 			"toc0":   sqltypes.Uint64BindVariable(1),

--- a/go/vt/vtgate/vindexes/lookup_hash_unique_test.go
+++ b/go/vt/vtgate/vindexes/lookup_hash_unique_test.go
@@ -74,7 +74,7 @@ func TestLookupHashUniqueCreate(t *testing.T) {
 		t.Error(err)
 	}
 	wantQuery := &querypb.BoundQuery{
-		Sql: "insert into t(fromc,toc) values(:fromc0,:toc0)",
+		Sql: "insert ignore into t(fromc,toc) values(:fromc0,:toc0)",
 		BindVariables: map[string]*querypb.BindVariable{
 			"fromc0": sqltypes.Int64BindVariable(1),
 			"toc0":   sqltypes.Uint64BindVariable(1),

--- a/go/vt/vtgate/vindexes/lookup_internal.go
+++ b/go/vt/vtgate/vindexes/lookup_internal.go
@@ -45,7 +45,7 @@ func (lkp *lookup) Init(lookupQueryParams map[string]string, isHashed bool) {
 	lkp.To = toCol
 	lkp.sel = fmt.Sprintf("select %s from %s where %s = :%s", toCol, table, fromCol, fromCol)
 	lkp.ver = fmt.Sprintf("select %s from %s where %s = :%s and %s = :%s", fromCol, table, fromCol, fromCol, toCol, toCol)
-	lkp.ins = fmt.Sprintf("insert into %s(%s, %s) values", table, fromCol, toCol)
+	lkp.ins = fmt.Sprintf("insert ignore into %s(%s, %s) values", table, fromCol, toCol)
 	lkp.del = fmt.Sprintf("delete from %s where %s = :%s and %s = :%s", table, fromCol, fromCol, toCol, toCol)
 	lkp.isHashedIndex = isHashed
 }
@@ -158,7 +158,7 @@ func (lkp *lookup) Create(vcursor VCursor, ids []sqltypes.Value, ksids [][]byte)
 	if len(ids) != len(ksids) {
 		return fmt.Errorf("lookup.Create:length of ids %v doesn't match length of ksids %v", len(ids), len(ksids))
 	}
-	insBuffer.WriteString("insert into ")
+	insBuffer.WriteString("insert ignore into ")
 	insBuffer.WriteString(lkp.Table)
 	insBuffer.WriteString("(")
 	insBuffer.WriteString(lkp.From)

--- a/go/vt/vtgate/vindexes/lookup_test.go
+++ b/go/vt/vtgate/vindexes/lookup_test.go
@@ -123,7 +123,7 @@ func TestLookupUniqueCreate(t *testing.T) {
 		t.Error(err)
 	}
 	wantQuery := &querypb.BoundQuery{
-		Sql: "insert into t(fromc,toc) values(:fromc0,:toc0)",
+		Sql: "insert ignore into t(fromc,toc) values(:fromc0,:toc0)",
 		BindVariables: map[string]*querypb.BindVariable{
 			"fromc0": sqltypes.Int64BindVariable(1),
 			"toc0":   sqltypes.BytesBindVariable([]byte("test")),
@@ -221,7 +221,7 @@ func TestLookupNonUniqueCreate(t *testing.T) {
 		t.Error(err)
 	}
 	wantQuery := &querypb.BoundQuery{
-		Sql: "insert into t(fromc,toc) values(:fromc0,:toc0)",
+		Sql: "insert ignore into t(fromc,toc) values(:fromc0,:toc0)",
 		BindVariables: map[string]*querypb.BindVariable{
 			"fromc0": sqltypes.Int64BindVariable(1),
 			"toc0":   sqltypes.BytesBindVariable([]byte("test")),

--- a/go/vt/vttablet/grpctabletconn/conn.go
+++ b/go/vt/vttablet/grpctabletconn/conn.go
@@ -77,6 +77,7 @@ func DialTablet(tablet *topodatapb.Tablet, timeout time.Duration) (queryservice.
 	if timeout > 0 {
 		opts = append(opts, grpc.WithBlock(), grpc.WithTimeout(timeout))
 	}
+	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(*grpcutils.MaxMessageSize), grpc.MaxCallSendMsgSize(*grpcutils.MaxMessageSize)))
 	cc, err := grpc.Dial(addr, opts...)
 	if err != nil {
 		return nil, err

--- a/go/vt/vttablet/tabletserver/txlogz.go
+++ b/go/vt/vttablet/tabletserver/txlogz.go
@@ -85,6 +85,17 @@ func txlogzHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	io.WriteString(w, `
+<!DOCTYPE html>
+<html>
+<body>
+<h1>Redacted</h1>
+<p>/txlogz has been redacted for your protection</p>
+</body>
+</html>
+	`)
+	return;
+
 	timeout, limit := parseTimeoutLimitParams(req)
 	ch := tabletenv.TxLogger.Subscribe("txlogz")
 	defer tabletenv.TxLogger.Unsubscribe(ch)

--- a/go/vt/vttablet/tabletserver/txlogz_test.go
+++ b/go/vt/vttablet/tabletserver/txlogz_test.go
@@ -32,6 +32,14 @@ func testHandler(req *http.Request, t *testing.T) {
 	response := httptest.NewRecorder()
 	tabletenv.TxLogger.Send("test msg")
 	txlogzHandler(response, req)
+
+	if !strings.Contains(response.Body.String(), "Redacted") {
+		t.Fatalf("should have been redacted")
+	}
+
+	// skip the rest of the test since it is now always redacted
+	return
+
 	if !strings.Contains(response.Body.String(), "error") {
 		t.Fatalf("should show an error page since transaction log format is invalid.")
 	}


### PR DESCRIPTION
# Overview

This branch contains an updated slack fork for vitess in a way that syncs us back with upstream/master and then applies three slack-specific patches that we still need to run with.

This PR is based off the `slack-new-master` branch. Once approved, I'll merge this PR into that branch, rename our existing master branch to`slack-old-master-20170821`, and force-push the merged `slack-new-master` as our new master branch.

# Details

To prepare the branch I looked through our history and found the earliest merge point.

From that I created two new tags:
  * slack-vitess-081417r0-base (7b7c6e6): the base of our current fork, including previous slack-specific history
  * slack-vitess-081417r0-upstream (a5a7253): upstream commit that we last synced.

The content of these two tags / commits are equivalent.

I then created a `slack-new-master` branch off of the latest upstream/master (8188623), and I created a tag with slack-vitess-082117r0-upstream at this merge point.

Then I went through all the slack-specific commits since our latest sync:

```
[SFO-M-MDEMMER01] -> git log --oneline --no-merges slack-vitess-081417r0-base..origin/master
b089a6f Refresh MySQL config after a backup
afe78be `insert ignore` hack for vindex lookup to be updated (#30)
ae637b5 Pin Travis test config to Ubuntu Precise.
bdad4c3 Fix for travis ci
4fcdc0a Fix mysql server test
6ce58f1 Allow VTDATAROOT to be configurable
66b1ee7 change autocommit default for all mysql sessions to true
f0004cf Revert "Merge pull request #22 from tinyspeck/hz_vitess"
0c24fdd ~ revert `vendor/vendor.json` changes
a628346 make grpc max message size options apply to the client as well
e7627dd fix test
628e6de fixing `disallow outside transactions` of select for update
fb0850c Testing 'Sanity healthcheck connections' commit https://github.com/youtube/vitess/pull/3004
80eac90 add temporary hack to ignore vindex insert duplicate errors
8eccb48 redact out the /txlogz endpoint completely
bfac6ab make the tablet identification added to errors more concise
```

Of these I cherry-picked three into this branch:

```
8eccb48 redact out the /txlogz endpoint completely
e07891a make grpc max message size options apply to the client as well
afe78be `insert ignore` hack for vindex lookup to be updated (#30)
```

For e07891a, I actually cherry-picked from my updated upstream branch to fix conflicts.
For afe78be there were a number of conflicts that I reconciled manually.

