### PR TITLE
Slack upstream sync 08.31.2017

### DIFF
--- a/go/sync2/consolidator.go
+++ b/go/sync2/consolidator.go
@@ -102,6 +102,19 @@ func NewConsolidatorCache(capacity int64) *ConsolidatorCache {
 
 // ServeHTTP lists the most recent, cached queries and their count.
 func (cc *ConsolidatorCache) ServeHTTP(response http.ResponseWriter, request *http.Request) {
+	if true {
+		response.Write([]byte(`
+	<!DOCTYPE html>
+	<html>
+	<body>
+	<h1>Redacted</h1>
+	<p>/debug/consolidations has been redacted for your protection</p>
+	</body>
+	</html>
+		`))
+		return
+	}
+
 	if err := acl.CheckAccessHTTP(request, acl.DEBUGGING); err != nil {
 		acl.SendError(response, err)
 		return

--- a/go/vt/servenv/grpcutils/options.go
+++ b/go/vt/servenv/grpcutils/options.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpcutils
+
+import (
+	"flag"
+)
+
+var (
+	defaultMaxMessageSize = 4 * 1024 * 1024
+	// MaxMessageSize is the maximum message size which the gRPC server will
+	// accept. Larger messages will be rejected.
+	MaxMessageSize = &defaultMaxMessageSize
+)
+
+// RegisterFlags registers the command line flags for common grpc options
+func RegisterFlags() {
+	// Note: We're using 4 MiB as default value because that's the default in the
+	// gRPC 1.0.0 Go server.
+	MaxMessageSize = flag.Int("grpc_max_message_size", defaultMaxMessageSize, "Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'.")
+}

--- a/go/vt/vtgate/grpcvtgateconn/conn.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn.go
@@ -58,7 +58,7 @@ func dial(ctx context.Context, addr string, timeout time.Duration) (vtgateconn.I
 	if err != nil {
 		return nil, err
 	}
-	cc, err := grpc.Dial(addr, opt, grpc.WithBlock(), grpc.WithTimeout(timeout))
+	cc, err := grpc.Dial(addr, opt, grpc.WithBlock(), grpc.WithTimeout(timeout), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(*grpcutils.MaxMessageSize), grpc.MaxCallSendMsgSize(*grpcutils.MaxMessageSize)))
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vttablet/grpctabletconn/conn.go
+++ b/go/vt/vttablet/grpctabletconn/conn.go
@@ -77,6 +77,7 @@ func DialTablet(tablet *topodatapb.Tablet, timeout time.Duration) (queryservice.
 	if timeout > 0 {
 		opts = append(opts, grpc.WithBlock(), grpc.WithTimeout(timeout))
 	}
+	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(*grpcutils.MaxMessageSize), grpc.MaxCallSendMsgSize(*grpcutils.MaxMessageSize)))
 	cc, err := grpc.Dial(addr, opts...)
 	if err != nil {
 		return nil, err

--- a/go/vt/vttablet/tabletserver/txlogz.go
+++ b/go/vt/vttablet/tabletserver/txlogz.go
@@ -85,6 +85,17 @@ func txlogzHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	io.WriteString(w, `
+<!DOCTYPE html>
+<html>
+<body>
+<h1>Redacted</h1>
+<p>/txlogz has been redacted for your protection</p>
+</body>
+</html>
+	`)
+	return;
+
 	timeout, limit := parseTimeoutLimitParams(req)
 	ch := tabletenv.TxLogger.Subscribe("txlogz")
 	defer tabletenv.TxLogger.Unsubscribe(ch)

--- a/go/vt/vttablet/tabletserver/txlogz_test.go
+++ b/go/vt/vttablet/tabletserver/txlogz_test.go
@@ -32,6 +32,14 @@ func testHandler(req *http.Request, t *testing.T) {
 	response := httptest.NewRecorder()
 	tabletenv.TxLogger.Send("test msg")
 	txlogzHandler(response, req)
+
+	if !strings.Contains(response.Body.String(), "Redacted") {
+		t.Fatalf("should have been redacted")
+	}
+
+	// skip the rest of the test since it is now always redacted
+	return
+
 	if !strings.Contains(response.Body.String(), "error") {
 		t.Fatalf("should show an error page since transaction log format is invalid.")
 	}

--- a/go/vt/vttablet/tabletserver/txserializer/tx_serializer_test.go
+++ b/go/vt/vttablet/tabletserver/txserializer/tx_serializer_test.go
@@ -130,17 +130,17 @@ func testHTTPHandler(txs *TxSerializer, count int) error {
 	}
 	rr := httptest.NewRecorder()
 	txs.ServeHTTP(rr, req)
-
-	if got, want := rr.Code, http.StatusOK; got != want {
-		return fmt.Errorf("wrong status code: got = %v, want = %v", got, want)
-	}
-	want := fmt.Sprintf(`Length: 1
-%d: t1 where1
-`, count)
-	if got := rr.Body.String(); got != want {
-		return fmt.Errorf("wrong content: got = \n%v\n want = \n%v", got, want)
-	}
-
+	/*
+			if got, want := rr.Code, http.StatusOK; got != want {
+				return fmt.Errorf("wrong status code: got = %v, want = %v", got, want)
+			}
+			want := fmt.Sprintf(`Length: 1
+		%d: t1 where1
+		`, count)
+			if got := rr.Body.String(); got != want {
+				return fmt.Errorf("wrong content: got = \n%v\n want = \n%v", got, want)
+			}
+	*/
 	return nil
 }
 


### PR DESCRIPTION
Preparation branch for the next upstream sync.

The latest upstream commit is 24c74fc tagged with slack-vitess-08.31.2017r0-upstream.
I force pushed that commit to the `slack-new-master` branch.

This shows all the upstream changes that we are pulling in:
https://github.com/tinyspeck/vitess/compare/tinyspeck:slack-vitess-082117r0-upstream...tinyspeck:slack-vitess-08.31.2017r0-upstream


These are the slack-specific patches on top of that.

As in #34, this also includes:
e1a81a1 make grpc max message size options apply to the client as well
4031aaf redact out the /txlogz endpoint completely

I did not include this since it should now be covered by the actual upstream fixes for upsert (#3066):
88860e5 `insert ignore` hack for vindex lookup to be updated

I also added the following:
1d544c9 redact out the /debug/consolidations UI

