### PR TITLE
Expose BuildNumber as a metric

### DIFF
--- a/tools/build_version_flags.sh
+++ b/tools/build_version_flags.sh
@@ -23,4 +23,5 @@ echo "\
   -X 'github.com/youtube/vitess/go/vt/servenv.buildGitRev=$(git rev-parse --short HEAD)' \
   -X 'github.com/youtube/vitess/go/vt/servenv.buildGitBranch=$(git rev-parse --abbrev-ref HEAD)' \
   -X 'github.com/youtube/vitess/go/vt/servenv.buildTime=$(LC_ALL=C date)' \
+  -X 'github.com/youtube/vitess/go/vt/servenv.buildNumberStr=${BUILD_NUMBER}' \
 "


### PR DESCRIPTION
Tested:
```
akotian@slack-vtctld-dev-025a0a18c54fb9a57:~$ ./vtctld -version 
Version: 1849db4 (91) (Git branch 'HEAD') built on Thu Oct  5 12:32:03 PDT 2017 by jenkinsslave@build-slave-vitess1604 using go1.8.3 linux/amd64
```
```

{
"BuildGitBranch": "HEAD",
"BuildGitRev": "1849db4",
"BuildHost": "build-slave-vitess1604",
"BuildNumber": 91,
"BuildTimestamp": 1507231923,
"BuildUser": "jenkinsslave",

```