### PR TITLE
add the StaticAuthDialOption to the binlogplayer grpc client

### DIFF
--- a/go/vt/binlog/grpcbinlogplayer/player.go
+++ b/go/vt/binlog/grpcbinlogplayer/player.go
@@ -41,7 +41,17 @@ type client struct {
 func (client *client) Dial(tablet *topodatapb.Tablet, connTimeout time.Duration) error {
 	addr := netutil.JoinHostPort(tablet.Hostname, tablet.PortMap["grpc"])
 	var err error
-	client.cc, err = grpcclient.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(connTimeout))
+
+	opts := []grpc.DialOption{
+		grpc.WithInsecure(),
+		grpc.WithTimeout(connTimeout),
+	}
+	opts, err = grpcclient.StaticAuthDialOption(opts, grpcclient.GetAuthStaticClientCreds())
+	if err != nil {
+		return err
+	}
+
+	client.cc, err = grpcclient.Dial(addr, opts...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This one was missed in the original implementation.

It's used during filtered replication to make a grpc call from one tablet to the other.
