### PR TITLE
remove debugging printf

### DIFF
--- a/go/vt/mysqlproxy/mysqlproxy.go
+++ b/go/vt/mysqlproxy/mysqlproxy.go
@@ -170,7 +170,6 @@ func (mp *Proxy) executeSelect(ctx context.Context, session *ProxySession, sql s
 		query, comments := sqlparser.SplitTrailingComments(sql)
 		stmt, err := sqlparser.Parse(query)
 		if err != nil {
-			fmt.Printf("YYY parse error  %s\n", query)
 			return nil, err
 		}
 		sqlparser.Normalize(stmt, bindVariables, "vtp")


### PR DESCRIPTION
This accidentally got left in and it exposes full queries in the debug log. So let's not do that.

