### PR TITLE
 Allow mysql to be used with a net.Listener created outside the mysql package

### DIFF
--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -116,6 +116,18 @@ type Listener struct {
 	connectionID uint32
 }
 
+// NewFromListener creares a new mysql listener from an existing net.Listener
+func NewFromListener(l net.Listener, authServer AuthServer, handler Handler) (*Listener, error) {
+	return &Listener{
+		authServer: authServer,
+		handler:    handler,
+		listener:   l,
+
+		ServerVersion: DefaultServerVersion,
+		connectionID:  1,
+	}, nil
+}
+
 // NewListener creates a new Listener.
 func NewListener(protocol, address string, authServer AuthServer, handler Handler) (*Listener, error) {
 	listener, err := net.Listen(protocol, address)
@@ -123,14 +135,7 @@ func NewListener(protocol, address string, authServer AuthServer, handler Handle
 		return nil, err
 	}
 
-	return &Listener{
-		authServer: authServer,
-		handler:    handler,
-		listener:   listener,
-
-		ServerVersion: DefaultServerVersion,
-		connectionID:  1,
-	}, nil
+	return NewFromListener(listener, authServer, handler)
 }
 
 // Addr returns the listener address.


### PR DESCRIPTION
Let's us control the creation of the net.Listener used by the mysql package.

We want this is we want to be able to gracefully drain the mysql connection.