### PR TITLE
Add a label to the tablet_state metric that attaches a label in the human readable form. 

### DIFF
--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -238,11 +238,11 @@ func NewTabletServer(config tabletenv.TabletConfig, topoServer *topo.Server, ali
 	// So that vtcombo doesn't even call it once, on the first tablet.
 	// And we can remove the tsOnce variable.
 	tsOnce.Do(func() {
-		stats.NewGaugeFunc("TabletState", "Tablet server state", func() int64 {
+		stats.NewGaugesFuncWithMultiLabels("TabletState", "Tablet server state", []string{"TabletStateName"}, func() map[string]int64 {
 			tsv.mu.Lock()
 			state := tsv.state
 			tsv.mu.Unlock()
-			return state
+			return map[string]int64{stateName[state] : state}
 		})
 		stats.NewGaugeDurationFunc("QueryTimeout", "Tablet server query timeout", tsv.QueryTimeout.Get)
 		stats.NewGaugeDurationFunc("QueryPoolTimeout", "Tablet server timeout to get a connection from the query pool", tsv.qe.connTimeout.Get)


### PR DESCRIPTION
We have an existing graph and alert that checks how many tablets in each cluster are in the SERVING state. This is a bit of a hack to allow us to continue to graph one metric per state a shard is in, even though the _value_ is equivalent to the enum value of the state (aka. `SERVING` = 2), there's no way to compare against the _value_ of a metric in PromQL, nor is there a way to export a String. Labeling the metric like this allows us to continue to have this graph/alert. 

Open to other suggestions for how to do this...

The outputted metric looks something like this for a `SERVING` tablet:

```
# TYPE vttablet_tablet_state gauge
vttablet_tablet_state{tablet_state_name="SERVING"} 2
```


