### PR TITLE
Add a stat to track the tablet type for Prometheus.

### DIFF
--- a/go/vt/vttablet/tabletmanager/action_agent.go
+++ b/go/vt/vttablet/tabletmanager/action_agent.go
@@ -98,6 +98,12 @@ type ActionAgent struct {
 	// only used if exportStats is true.
 	statsTabletType *stats.String
 
+	// statsTabletTypeCount exposes the current tablet type as a label,
+	// with the value counting the occurances of the respective tablet type.
+	// Useful for Prometheus which doesn't support exporting strings as stat values
+	// only used if exportStats is true.
+	statsTabletTypeCount *stats.CountersWithSingleLabel
+
 	// batchCtx is given to the agent by its creator, and should be used for
 	// any background tasks spawned by the agent.
 	batchCtx context.Context
@@ -238,6 +244,7 @@ func NewActionAgent(
 	// Create the TabletType stats
 	agent.exportStats = true
 	agent.statsTabletType = stats.NewString("TabletType")
+	agent.statsTabletTypeCount = stats.NewCountersWithSingleLabel("TabletTypeCount", "Number of state change to the labeled topodata.TabletType", "type")
 
 	// Start the binlog player services, not playing at start.
 	agent.BinlogPlayerMap = NewBinlogPlayerMap(ts, mysqld, func() binlogplayer.VtClient {

--- a/go/vt/vttablet/tabletmanager/state_change.go
+++ b/go/vt/vttablet/tabletmanager/state_change.go
@@ -300,7 +300,9 @@ func (agent *ActionAgent) changeCallback(ctx context.Context, oldTablet, newTabl
 
 	// Update the stats to our current type.
 	if agent.exportStats {
-		agent.statsTabletType.Set(topoproto.TabletTypeLString(newTablet.Type))
+		s := topoproto.TabletTypeLString(newTablet.Type)
+		agent.statsTabletType.Set(s)
+		agent.statsTabletTypeCount.Add(1, s)
 	}
 
 	// See if we need to start or stop any binlog player.


### PR DESCRIPTION
Adds a new stat to track the tablet type in a format that's exportable to Prometheus. 