### PR TITLE
Fix bug found in dev with empty length active-recovery response.

### DIFF
--- a/go/vt/vttablet/tabletmanager/orchestrator.go
+++ b/go/vt/vttablet/tabletmanager/orchestrator.go
@@ -146,8 +146,9 @@ func (orc *orcClient) InActiveShardRecovery(tablet *topodatapb.Tablet) (bool, er
 		return false, err
 	}
 
+	// Orchestrator returns a 0-length response when it has no history of recovery on this cluster.
 	if len(r) == 0 {
-		return false, fmt.Errorf("Orchestrator returned an empty audit-recovery response")
+		return false, nil
 	}
 
 	active, ok := r[0]["IsActive"].(bool)


### PR DESCRIPTION
Fix bug found in dev: Orchestrator returns an empty length active-recovery response when it has no history of recovery on that cluster. An empty length active-recovery response is normal, and should mean that Orchestrator is not actively recovering that instance.