### PR TITLE
Fix QueryCounts spike-iness 

### DIFF
--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -62,41 +62,11 @@ type TabletPlan struct {
 	Rules            *rules.Rules
 	LegacyAuthorized *tableacl.ACLResult
 	Authorized       []*tableacl.ACLResult
-
-	mu         sync.Mutex
-	QueryCount int64
-	Time       time.Duration
-	MysqlTime  time.Duration
-	RowCount   int64
-	ErrorCount int64
 }
 
 // Size allows TabletPlan to be in cache.LRUCache.
 func (*TabletPlan) Size() int {
 	return 1
-}
-
-// AddStats updates the stats for the current TabletPlan.
-func (ep *TabletPlan) AddStats(queryCount int64, duration, mysqlTime time.Duration, rowCount, errorCount int64) {
-	ep.mu.Lock()
-	ep.QueryCount += queryCount
-	ep.Time += duration
-	ep.MysqlTime += mysqlTime
-	ep.RowCount += rowCount
-	ep.ErrorCount += errorCount
-	ep.mu.Unlock()
-}
-
-// Stats returns the current stats of TabletPlan.
-func (ep *TabletPlan) Stats() (queryCount int64, duration, mysqlTime time.Duration, rowCount, errorCount int64) {
-	ep.mu.Lock()
-	queryCount = ep.QueryCount
-	duration = ep.Time
-	mysqlTime = ep.MysqlTime
-	rowCount = ep.RowCount
-	errorCount = ep.ErrorCount
-	ep.mu.Unlock()
-	return
 }
 
 // buildAuthorized builds 'Authorized', which is the runtime part for 'Permissions'.
@@ -125,6 +95,9 @@ type QueryEngine struct {
 	tables           map[string]*schema.Table
 	plans            *cache.LRUCache
 	queryRuleSources *rules.Map
+
+	qsMu sync.RWMutex
+	qs   map[string]*QueryStats
 
 	// Pools
 	conns       *connpool.Pool
@@ -182,6 +155,7 @@ func NewQueryEngine(checker connpool.MySQLChecker, se *schema.Engine, config tab
 		plans:              cache.NewLRUCache(int64(config.QueryPlanCacheSize)),
 		queryRuleSources:   rules.NewMap(),
 		queryPoolWaiterCap: sync2.NewAtomicInt64(int64(config.QueryPoolWaiterCap)),
+		qs:                 make(map[string]*QueryStats),
 	}
 
 	qe.conns = connpool.New(
@@ -478,53 +452,75 @@ func (qe *QueryEngine) QueryPlanCacheCap() int {
 	return int(qe.plans.Capacity())
 }
 
-func (qe *QueryEngine) getQueryCount() map[string]int64 {
-	f := func(plan *TabletPlan) int64 {
-		queryCount, _, _, _, _ := plan.Stats()
-		return queryCount
+type QueryStats struct {
+	queryCount int64
+	time       time.Duration
+	mysqlTime  time.Duration
+	rowCount   int64
+	errorCount int64
+}
+
+func (qe *QueryEngine) AddStats(planName, tableName string, queryCount int64, duration, mysqlTime time.Duration, rowCount, errorCount int64) {
+	qe.qsMu.Lock()
+	defer qe.qsMu.Unlock()
+
+	p := &QueryStats{
+		queryCount: queryCount,
+		time:       duration,
+		mysqlTime:  mysqlTime,
+		rowCount:   rowCount,
+		errorCount: errorCount}
+
+	if stats := qe.Stats(planName, tableName); stats != nil {
+		p = &QueryStats{
+			queryCount: stats.queryCount + queryCount,
+			time:       stats.time + duration,
+			mysqlTime:  stats.mysqlTime + mysqlTime,
+			rowCount:   stats.rowCount + rowCount,
+			errorCount: stats.errorCount + errorCount}
 	}
-	return qe.getQueryStats(f)
+
+	qe.qs[planName+"."+tableName] = p
+}
+
+func (qe *QueryEngine) Stats(planName, tableName string) *QueryStats {
+	qe.qsMu.Lock()
+	defer qe.qsMu.Unlock()
+	s, ok := qe.qs[planName+"."+tableName]
+	if !ok {
+		return nil
+	}
+	return s
+}
+
+func (qe *QueryEngine) getQueryCount() map[string]int64 {
+	qstats := make(map[string]int64)
+	for k, qs := range qe.qs {
+		qstats[k] = qs.queryCount
+	}
+	return qstats
 }
 
 func (qe *QueryEngine) getQueryTime() map[string]int64 {
-	f := func(plan *TabletPlan) int64 {
-		_, time, _, _, _ := plan.Stats()
-		return int64(time)
+	qstats := make(map[string]int64)
+	for k, qs := range qe.qs {
+		qstats[k] = int64(qs.time)
 	}
-	return qe.getQueryStats(f)
+	return qstats
 }
 
 func (qe *QueryEngine) getQueryRowCount() map[string]int64 {
-	f := func(plan *TabletPlan) int64 {
-		_, _, _, rowCount, _ := plan.Stats()
-		return rowCount
+	qstats := make(map[string]int64)
+	for k, qs := range qe.qs {
+		qstats[k] = qs.rowCount
 	}
-	return qe.getQueryStats(f)
+	return qstats
 }
 
 func (qe *QueryEngine) getQueryErrorCount() map[string]int64 {
-	f := func(plan *TabletPlan) int64 {
-		_, _, _, _, errorCount := plan.Stats()
-		return errorCount
-	}
-	return qe.getQueryStats(f)
-}
-
-type queryStatsFunc func(*TabletPlan) int64
-
-func (qe *QueryEngine) getQueryStats(f queryStatsFunc) map[string]int64 {
-	keys := qe.plans.Keys()
 	qstats := make(map[string]int64)
-	for _, v := range keys {
-		if plan := qe.peekQuery(v); plan != nil {
-			table := plan.TableName()
-			if table.IsEmpty() {
-				table = sqlparser.NewTableIdent("Join")
-			}
-			planType := plan.PlanID.String()
-			data := f(plan)
-			qstats[table.String()+"."+planType] += data
-		}
+	for k, qs := range qe.qs {
+		qstats[k] = qs.errorCount
 	}
 	return qstats
 }
@@ -588,7 +584,14 @@ func (qe *QueryEngine) handleHTTPQueryStats(response http.ResponseWriter, reques
 			pqstats.Query = unicoded(sqlparser.TruncateForUI(v))
 			pqstats.Table = plan.TableName().String()
 			pqstats.Plan = plan.PlanID
-			pqstats.QueryCount, pqstats.Time, pqstats.MysqlTime, pqstats.RowCount, pqstats.ErrorCount = plan.Stats()
+			if stats := qe.Stats(pqstats.Plan.String(), pqstats.Table); stats != nil {
+				pqstats.QueryCount = stats.queryCount
+				pqstats.Time = stats.time
+				pqstats.MysqlTime = stats.mysqlTime
+				pqstats.RowCount = stats.rowCount
+				pqstats.ErrorCount = stats.errorCount
+			}
+
 			qstats = append(qstats, pqstats)
 		}
 	}

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -471,7 +471,7 @@ func (qe *QueryEngine) AddStats(planName, tableName string, queryCount int64, du
 		rowCount:   rowCount,
 		errorCount: errorCount}
 
-	if stats := qe.Stats(planName, tableName); stats != nil {
+	if stats, ok := qe.qs[planName+"."+tableName]; ok {
 		p = &QueryStats{
 			queryCount: stats.queryCount + queryCount,
 			time:       stats.time + duration,

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -80,10 +80,10 @@ func (qre *QueryExecutor) Execute() (reply *sqltypes.Result, err error) {
 		tabletenv.RecordUserQuery(qre.ctx, qre.plan.TableName(), "Execute", int64(duration))
 
 		if reply == nil {
-			qre.plan.AddStats(1, duration, qre.logStats.MysqlResponseTime, 0, 1)
+			qre.tsv.qe.AddStats(planName, qre.plan.TableName().String(), 1, duration, qre.logStats.MysqlResponseTime, 0, 1)
 			return
 		}
-		qre.plan.AddStats(1, duration, qre.logStats.MysqlResponseTime, int64(reply.RowsAffected), 0)
+		qre.tsv.qe.AddStats(planName, qre.plan.TableName().String(), 1, duration, qre.logStats.MysqlResponseTime, int64(reply.RowsAffected), 0)
 		qre.logStats.RowsAffected = int(reply.RowsAffected)
 		qre.logStats.Rows = reply.Rows
 		tabletenv.ResultStats.Add(int64(len(reply.Rows)))

--- a/go/vt/vttablet/tabletserver/queryz.go
+++ b/go/vt/vttablet/tabletserver/queryz.go
@@ -155,7 +155,12 @@ func queryzHandler(qe *QueryEngine, w http.ResponseWriter, r *http.Request) {
 			Plan:   plan.PlanID,
 			Reason: plan.Reason,
 		}
-		Value.Count, Value.tm, Value.mysqlTime, Value.Rows, Value.Errors = plan.Stats()
+		qs := qe.Stats(plan.PlanID.String(), plan.TableName().String())
+		Value.Count = qs.queryCount
+		Value.tm = qs.time
+		Value.mysqlTime = qs.mysqlTime
+		Value.Rows = qs.rowCount
+		Value.Errors = qs.errorCount
 		var timepq time.Duration
 		if Value.Count != 0 {
 			timepq = time.Duration(int64(Value.tm) / Value.Count)

--- a/go/vt/vttablet/tabletserver/queryz_test.go
+++ b/go/vt/vttablet/tabletserver/queryz_test.go
@@ -44,7 +44,7 @@ func TestQueryzHandler(t *testing.T) {
 			Reason: planbuilder.ReasonTable,
 		},
 	}
-	plan1.AddStats(10, 2*time.Second, 1*time.Second, 2, 0)
+	qe.AddStats(plan1.PlanID.String(), "test_table", 10, 2*time.Second, 1*time.Second, 2, 0)
 	qe.plans.Set("select name from test_table", plan1)
 
 	plan2 := &TabletPlan{
@@ -54,7 +54,7 @@ func TestQueryzHandler(t *testing.T) {
 			Reason: planbuilder.ReasonDefault,
 		},
 	}
-	plan2.AddStats(1, 2*time.Millisecond, 1*time.Millisecond, 1, 0)
+	qe.AddStats(plan2.PlanID.String(), "test_table", 1, 2*time.Millisecond, 1*time.Millisecond, 1, 0)
 	qe.plans.Set("insert into test_table values 1", plan2)
 
 	plan3 := &TabletPlan{
@@ -64,7 +64,7 @@ func TestQueryzHandler(t *testing.T) {
 			Reason: planbuilder.ReasonDefault,
 		},
 	}
-	plan3.AddStats(1, 75*time.Millisecond, 50*time.Millisecond, 1, 0)
+	qe.AddStats(plan3.PlanID.String(), "", 1, 75*time.Millisecond, 50*time.Millisecond, 1, 0)
 	qe.plans.Set("show tables", plan3)
 	qe.plans.Set("", (*TabletPlan)(nil))
 
@@ -75,7 +75,7 @@ func TestQueryzHandler(t *testing.T) {
 			Reason: planbuilder.ReasonDefault,
 		},
 	}
-	plan4.AddStats(1, 1*time.Millisecond, 1*time.Millisecond, 1, 0)
+	qe.AddStats(plan4.PlanID.String(), "", 1, 1*time.Millisecond, 1*time.Millisecond, 1, 0)
 	hugeInsert := "insert into test_table values 0"
 	for i := 1; i < 1000; i++ {
 		hugeInsert = hugeInsert + fmt.Sprintf(", %d", i)


### PR DESCRIPTION
Keep track of QueryStats in the QueryEngine instead of the TabletPlan so that it doesn't get LRU evicted as part of the TabletPlanCache.