### PR TITLE
Cherry-pick: Follow the MySQL handshake protocol and send 10 NULL bytes

### DIFF
--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -521,8 +521,8 @@ func (c *Conn) writeHandshakeV10(serverVersion string, authServer AuthServer, en
 	// Always 21 (8 + 13).
 	pos = writeByte(data, pos, 21)
 
-	// Reserved
-	pos += 10
+	// Reserved 10 bytes: all 0
+	pos = writeZeroes(data, pos, 10)
 
 	// Second part of auth plugin data.
 	pos += copy(data[pos:], salt[8:])


### PR DESCRIPTION
### Description 

Change the MySQL handshake to send 10 null bytes instead of 10 bytes from the buffer. 

Cherry-picks: https://github.com/vitessio/vitess/pull/4283 