### PR TITLE
Upgrade Java to 8

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -222,10 +222,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.8.0</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <!-- Add "dependency:analyze" to "verify" goal. -->


### PR DESCRIPTION
The project already depends on Guava 26.0-jre, which reuqires Java 8. Without this change, the project doesn't even compile in IntelliJ.