### PR TITLE
Add Python source and binary (wheel) build/distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ vthook*
 bin*
 
 vtdataroot*
+# Python
+py/dist/

--- a/Makefile
+++ b/Makefile
@@ -283,3 +283,12 @@ minimaltools:
 
 dependency_check:
 	./tools/dependency_check.sh
+clean-py:
+	rm -rf py/dist
+	rm -rf py/build
+
+py-release: clean-py
+	cd ${PWD}/py && python setup.py sdist bdist_wheel && cd ../
+	echo "Finished building!"
+	echo "Upload to pypi by running:"
+	echo "python3 -m twine upload py/dist/*"

--- a/py/requirements_dev.txt
+++ b/py/requirements_dev.txt
@@ -1,3 +1,2 @@
-bumpversion==0.5.3
 pip==20.0.2
 setuptools==45.1.0

--- a/py/requirements_dev.txt
+++ b/py/requirements_dev.txt
@@ -1,0 +1,3 @@
+bumpversion==0.5.3
+pip==20.0.2
+setuptools==45.1.0

--- a/py/setup.cfg
+++ b/py/setup.cfg
@@ -1,0 +1,22 @@
+[bumpversion]
+current_version = 4.0.1
+commit = True
+tag = True
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
+	(?:
+	(?P<prerel>[abc]|rc|dev)     # 'a' = alpha, 'b' = beta
+	(?:
+	(?P<prerelversion>\d+(?:\.\d+)*)
+	)?
+	)?
+serialize = 
+	{major}.{minor}.{patch}{prerel}{prerelversion}
+	{major}.{minor}.{patch}{prerel}
+	{major}.{minor}.{patch}
+
+[bumpversion:file:setup.py]
+search = __version__ = '{current_version}'
+replace = __version__ = '{new_version}'
+
+[bdist_wheel]
+universal = 1

--- a/py/setup.cfg
+++ b/py/setup.cfg
@@ -1,22 +1,2 @@
-[bumpversion]
-current_version = 4.0.1
-commit = True
-tag = True
-parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
-	(?:
-	(?P<prerel>[abc]|rc|dev)     # 'a' = alpha, 'b' = beta
-	(?:
-	(?P<prerelversion>\d+(?:\.\d+)*)
-	)?
-	)?
-serialize = 
-	{major}.{minor}.{patch}{prerel}{prerelversion}
-	{major}.{minor}.{patch}{prerel}
-	{major}.{minor}.{patch}
-
-[bumpversion:file:setup.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
-
 [bdist_wheel]
 universal = 1

--- a/py/setup.py
+++ b/py/setup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Copyright 2019 The Vitess Authors.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,10 +15,17 @@
 """This is the setup script for the submodules in the Vitess python client.
 """
 
-from distutils.core import setup
+__version__ = '4.0.1'
+from setuptools import setup
 
-
-setup(name="vitess",
+setup(
+      name="vitess",
       packages=["vtctl", "vtdb", "vtproto", "vttest", "util"],
-      platforms="Any",
+      platforms='Linux',
+      setup_requires=['wheel'],
+      install_requires=[
+            'protobuf',
+            'grpcio'
+      ],
+      version=__version__
      )


### PR DESCRIPTION
## Description

This PR adds Python source (tarball) and binary (.whl) builds and distribution via a Makefile target.

To build, run:

`make py-release`

```
$ ls py/dist 
vitess-4.0.1-py2.py3-none-any.whl  vitess-4.0.1.tar.gz
```