### PR TITLE
Slack vitess 2020 03 11.r0

### DIFF
--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -54,6 +54,7 @@ var (
 	timings    = stats.NewTimings("MysqlServerTimings", "MySQL server timings", "operation")
 	connCount  = stats.NewGauge("MysqlServerConnCount", "Active MySQL server connections")
 	connAccept = stats.NewCounter("MysqlServerConnAccepted", "Connections accepted by MySQL server")
+	connRefuse = stats.NewCounter("MysqlServerConnRefused", "Connections refused by MySQL server")
 	connSlow   = stats.NewCounter("MysqlServerConnSlow", "Connections that took more than the configured mysql_slow_connect_warn_threshold to establish")
 
 	connCountByTLSVer = stats.NewGaugesWithSingleLabel("MysqlServerConnCountByTLSVer", "Active MySQL server connections by TLS version", "tls")
@@ -243,6 +244,7 @@ func (l *Listener) Accept() {
 		conn, err := l.listener.Accept()
 		if err != nil {
 			// Close() was probably called.
+			connRefuse.Add(1)
 			return
 		}
 

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -545,6 +545,7 @@ func TestServer(t *testing.T) {
 	initialTimingCounts := timings.Counts()
 	initialConnAccept := connAccept.Get()
 	initialConnSlow := connSlow.Get()
+	initialconnRefuse := connRefuse.Get()
 
 	l.SlowConnectWarnThreshold = time.Duration(time.Nanosecond * 1)
 
@@ -566,6 +567,9 @@ func TestServer(t *testing.T) {
 	}
 	if connSlow.Get()-initialConnSlow != 1 {
 		t.Errorf("Expected ConnSlow delta=1, got %d", connSlow.Get()-initialConnSlow)
+	}
+	if connRefuse.Get()-initialconnRefuse != 0 {
+		t.Errorf("Expected connRefuse delta=0, got %d", connRefuse.Get()-initialconnRefuse)
 	}
 
 	expectedTimingDeltas := map[string]int64{
@@ -603,6 +607,9 @@ func TestServer(t *testing.T) {
 	}
 	if connSlow.Get()-initialConnSlow != 1 {
 		t.Errorf("Expected ConnSlow delta=1, got %d", connSlow.Get()-initialConnSlow)
+	}
+	if connRefuse.Get()-initialconnRefuse != 0 {
+		t.Errorf("Expected connRefuse delta=0, got %d", connRefuse.Get()-initialconnRefuse)
 	}
 
 	// Run a 'select rows' command with results.
@@ -1251,6 +1258,7 @@ func TestListenerShutdown(t *testing.T) {
 		Uname: "user1",
 		Pass:  "password1",
 	}
+	initialconnRefuse := connRefuse.Get()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1265,6 +1273,10 @@ func TestListenerShutdown(t *testing.T) {
 	}
 
 	l.Shutdown()
+
+	if connRefuse.Get()-initialconnRefuse != 1 {
+		t.Errorf("Expected connRefuse delta=1, got %d", connRefuse.Get()-initialconnRefuse)
+	}
 
 	if err := conn.Ping(); err != nil {
 		sqlErr, ok := err.(*SQLError)

--- a/go/vt/discovery/topology_watcher.go
+++ b/go/vt/discovery/topology_watcher.go
@@ -437,3 +437,59 @@ func (fbs *FilterByShard) isIncluded(tablet *topodatapb.Tablet) bool {
 	}
 	return false
 }
+
+// FilterByKeyspace is a TabletRecorder filter that filters tablets by
+// keyspace
+type FilterByKeyspace struct {
+	tr TabletRecorder
+
+	keyspaces map[string]bool
+}
+
+// NewFilterByKeyspace creates a new FilterByKeyspace on top of an existing
+// TabletRecorder. Each filter is a keyspace entry. All tablets that match
+// a keyspace will be forwarded to the underlying TabletRecorder.
+func NewFilterByKeyspace(tr TabletRecorder, selectedKeyspaces []string) *FilterByKeyspace {
+	m := make(map[string]bool)
+	for _, keyspace := range selectedKeyspaces {
+		m[keyspace] = true
+	}
+
+	return &FilterByKeyspace{
+		tr:        tr,
+		keyspaces: m,
+	}
+}
+
+// AddTablet is part of the TabletRecorder interface.
+func (fbk *FilterByKeyspace) AddTablet(tablet *topodatapb.Tablet, name string) {
+	if fbk.isIncluded(tablet) {
+		fbk.tr.AddTablet(tablet, name)
+	}
+}
+
+// RemoveTablet is part of the TabletRecorder interface.
+func (fbk *FilterByKeyspace) RemoveTablet(tablet *topodatapb.Tablet) {
+	if fbk.isIncluded(tablet) {
+		fbk.tr.RemoveTablet(tablet)
+	}
+}
+
+// ReplaceTablet is part of the TabletRecorder interface.
+func (fbk *FilterByKeyspace) ReplaceTablet(old *topodatapb.Tablet, new *topodatapb.Tablet, name string) {
+	if old.Keyspace != new.Keyspace {
+		log.Errorf("Error replacing old tablet in %v with new tablet in %v", old.Keyspace, new.Keyspace)
+		return
+	}
+
+	if fbk.isIncluded(new) {
+		fbk.tr.ReplaceTablet(old, new, name)
+	}
+}
+
+// isIncluded returns true if the tablet's keyspace should be
+// forwarded to the underlying TabletRecorder.
+func (fbk *FilterByKeyspace) isIncluded(tablet *topodatapb.Tablet) bool {
+	_, exist := fbk.keyspaces[tablet.Keyspace]
+	return exist
+}

--- a/go/vt/topo/consultopo/watch.go
+++ b/go/vt/topo/consultopo/watch.go
@@ -58,6 +58,12 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 	go func() {
 		defer close(notifications)
 
+		var getCtx context.Context
+		// Initialize to no-op function to avoid having to check for nil.
+		cancelGetCtx := func() {}
+
+		defer cancelGetCtx()
+
 		for {
 			// Wait/poll until we get a new version.
 			// Get with a WaitIndex and WaitTime will return
@@ -65,14 +71,24 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 			// if it didn't change. So we just check for that
 			// and swallow the notifications when version matches.
 			waitIndex := pair.ModifyIndex
-			pair, _, err = s.kv.Get(nodePath, &api.QueryOptions{
+			opts := &api.QueryOptions{
 				WaitIndex: waitIndex,
 				WaitTime:  *watchPollDuration,
-			})
+			}
+
+			// Make a new Context for just this one Get() call.
+			// The server should send us something after WaitTime at the latest.
+			// If it takes more than 2x that long, assume we've lost contact.
+			// This essentially uses WaitTime as a heartbeat interval to detect
+			// a dead connection.
+			cancelGetCtx()
+			getCtx, cancelGetCtx = context.WithTimeout(watchCtx, 2*opts.WaitTime)
+
+			pair, _, err = s.kv.Get(nodePath, opts.WithContext(getCtx))
 			if err != nil {
-				// Serious error.
+				// Serious error or context timeout/cancelled.
 				notifications <- &topo.WatchData{
-					Err: err,
+					Err: convertError(err, nodePath),
 				}
 				return
 			}

--- a/go/vt/vtgate/gateway/discoverygateway.go
+++ b/go/vt/vtgate/gateway/discoverygateway.go
@@ -125,6 +125,8 @@ func createDiscoveryGateway(ctx context.Context, hc discovery.HealthCheck, serv 
 				log.Exitf("Cannot parse tablet_filters parameter: %v", err)
 			}
 			tr = fbs
+		} else if len(KeyspacesToWatch) > 0 {
+			tr = discovery.NewFilterByKeyspace(dg.hc, KeyspacesToWatch)
 		}
 
 		ctw := discovery.NewCellTabletsWatcher(ctx, topoServer, tr, c, *refreshInterval, *refreshKnownTablets, *topoReadConcurrency)

--- a/go/vt/vtgate/gateway/discoverygateway.go
+++ b/go/vt/vtgate/gateway/discoverygateway.go
@@ -38,18 +38,20 @@ import (
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/proto/topodata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 )
 
 var (
-	cellsToWatch        = flag.String("cells_to_watch", "", "comma-separated list of cells for watching tablets")
-	tabletFilters       flagutil.StringListValue
-	refreshInterval     = flag.Duration("tablet_refresh_interval", 1*time.Minute, "tablet refresh interval")
-	refreshKnownTablets = flag.Bool("tablet_refresh_known_tablets", true, "tablet refresh reloads the tablet address/port map from topo in case it changes")
-	topoReadConcurrency = flag.Int("topo_read_concurrency", 32, "concurrent topo reads")
-	allowedTabletTypes  []topodatapb.TabletType
+	cellsToWatch         = flag.String("cells_to_watch", "", "comma-separated list of cells for watching tablets")
+	tabletFilters        flagutil.StringListValue
+	refreshInterval      = flag.Duration("tablet_refresh_interval", 1*time.Minute, "tablet refresh interval")
+	refreshKnownTablets  = flag.Bool("tablet_refresh_known_tablets", true, "tablet refresh reloads the tablet address/port map from topo in case it changes")
+	topoReadConcurrency  = flag.Int("topo_read_concurrency", 32, "concurrent topo reads")
+	allowedTabletTypes   []topodatapb.TabletType
+	routeReplicaToRdonly = flag.Bool("gateway_route_replica_to_rdonly", false, "route REPLICA queries to RDONLY tablets as well as REPLICA tablets")
 )
 
 const (
@@ -287,6 +289,12 @@ func (dg *discoveryGateway) withRetry(ctx context.Context, target *querypb.Targe
 		}
 
 		tablets := dg.tsc.GetHealthyTabletStats(target.Keyspace, target.Shard, target.TabletType)
+
+		// temporary hack to enable REPLICA type queries to address both REPLICA tablets and RDONLY tablets
+		if *routeReplicaToRdonly && target.TabletType == topodata.TabletType_REPLICA {
+			tablets = append(tablets, dg.tsc.GetHealthyTabletStats(target.Keyspace, target.Shard, topodata.TabletType_RDONLY)...)
+		}
+
 		if len(tablets) == 0 {
 			// fail fast if there is no tablet
 			err = vterrors.New(vtrpcpb.Code_UNAVAILABLE, "no valid tablet")

--- a/go/vt/wrangler/tablet_test.go
+++ b/go/vt/wrangler/tablet_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package wrangler
 
 import (
+	"strings"
 	"testing"
 
 	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/logutil"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 )
 
@@ -54,5 +56,125 @@ func TestInitTabletShardConversion(t *testing.T) {
 	}
 	if string(ti.KeyRange.Start) != "\x80" || string(ti.KeyRange.End) != "\xc0" {
 		t.Errorf("Got wrong tablet.KeyRange, got %v expected 80-c0", ti.KeyRange)
+	}
+}
+
+// TestDeleteTabletBasic tests delete of non-master tablet
+func TestDeleteTabletBasic(t *testing.T) {
+	cell := "cell1"
+	ts := memorytopo.NewServer(cell)
+	wr := New(logutil.NewConsoleLogger(), ts, nil)
+
+	tablet := &topodatapb.Tablet{
+		Alias: &topodatapb.TabletAlias{
+			Cell: cell,
+			Uid:  1,
+		},
+		Shard: "0",
+	}
+
+	if err := wr.InitTablet(context.Background(), tablet, false /*allowMasterOverride*/, true /*createShardAndKeyspace*/, false /*allowUpdate*/); err != nil {
+		t.Fatalf("InitTablet failed: %v", err)
+	}
+
+	if _, err := ts.GetTablet(context.Background(), tablet.Alias); err != nil {
+		t.Fatalf("GetTablet failed: %v", err)
+	}
+
+	if err := wr.DeleteTablet(context.Background(), tablet.Alias, false); err != nil {
+		t.Fatalf("DeleteTablet failed: %v", err)
+	}
+}
+
+// TestDeleteTabletTrueMaster tests that you can delete a true master tablet
+// only if allowMaster is set to true
+func TestDeleteTabletTrueMaster(t *testing.T) {
+	cell := "cell1"
+	ts := memorytopo.NewServer(cell)
+	wr := New(logutil.NewConsoleLogger(), ts, nil)
+
+	tablet := &topodatapb.Tablet{
+		Alias: &topodatapb.TabletAlias{
+			Cell: cell,
+			Uid:  1,
+		},
+		Keyspace: "test",
+		Shard:    "0",
+		Type:     topodatapb.TabletType_MASTER,
+	}
+
+	if err := wr.InitTablet(context.Background(), tablet, false /*allowMasterOverride*/, true /*createShardAndKeyspace*/, false /*allowUpdate*/); err != nil {
+		t.Fatalf("InitTablet failed: %v", err)
+	}
+	if _, err := ts.GetTablet(context.Background(), tablet.Alias); err != nil {
+		t.Fatalf("GetTablet failed: %v", err)
+	}
+
+	// set MasterAlias and MasterTermStartTime on shard to match chosen master tablet
+	if _, err := ts.UpdateShardFields(context.Background(), "test", "0", func(si *topo.ShardInfo) error {
+		si.MasterAlias = tablet.Alias
+		si.MasterTermStartTime = tablet.MasterTermStartTime
+		return nil
+	}); err != nil {
+		t.Fatalf("UpdateShardFields failed: %v", err)
+	}
+
+	err := wr.DeleteTablet(context.Background(), tablet.Alias, false)
+	wantError := "as it is a master, use allow_master flag"
+	if err == nil || !strings.Contains(err.Error(), wantError) {
+		t.Fatalf("DeleteTablet on master: want error = %v, got error = %v", wantError, err)
+	}
+
+	if err := wr.DeleteTablet(context.Background(), tablet.Alias, true); err != nil {
+		t.Fatalf("DeleteTablet failed: %v", err)
+	}
+}
+
+// TestDeleteTabletFalseMaster tests that you can delete a false master tablet
+// with allowMaster set to false
+func TestDeleteTabletFalseMaster(t *testing.T) {
+	cell := "cell1"
+	ts := memorytopo.NewServer(cell)
+	wr := New(logutil.NewConsoleLogger(), ts, nil)
+
+	tablet1 := &topodatapb.Tablet{
+		Alias: &topodatapb.TabletAlias{
+			Cell: cell,
+			Uid:  1,
+		},
+		Keyspace: "test",
+		Shard:    "0",
+		Type:     topodatapb.TabletType_MASTER,
+	}
+
+	if err := wr.InitTablet(context.Background(), tablet1, false /*allowMasterOverride*/, true /*createShardAndKeyspace*/, false /*allowUpdate*/); err != nil {
+		t.Fatalf("InitTablet failed: %v", err)
+	}
+
+	tablet2 := &topodatapb.Tablet{
+		Alias: &topodatapb.TabletAlias{
+			Cell: cell,
+			Uid:  2,
+		},
+		Keyspace: "test",
+		Shard:    "0",
+		Type:     topodatapb.TabletType_MASTER,
+	}
+	if err := wr.InitTablet(context.Background(), tablet2, true /*allowMasterOverride*/, false /*createShardAndKeyspace*/, false /*allowUpdate*/); err != nil {
+		t.Fatalf("InitTablet failed: %v", err)
+	}
+
+	// set MasterAlias and MasterTermStartTime on shard to match chosen master tablet
+	if _, err := ts.UpdateShardFields(context.Background(), "test", "0", func(si *topo.ShardInfo) error {
+		si.MasterAlias = tablet2.Alias
+		si.MasterTermStartTime = tablet2.MasterTermStartTime
+		return nil
+	}); err != nil {
+		t.Fatalf("UpdateShardFields failed: %v", err)
+	}
+
+	// Should be able to delete old (false) master with allowMaster = false
+	if err := wr.DeleteTablet(context.Background(), tablet1.Alias, false); err != nil {
+		t.Fatalf("DeleteTablet failed: %v", err)
 	}
 }


### PR DESCRIPTION
Adhoc deploy containing _just_ the following changes:

* commit https://github.com/vitessio/vitess/commit/2f0e6ae10f8d420cb227c735ea497186f22d7a64, PR https://github.com/vitessio/vitess/pull/5647 from planetscale/ds-delete-tablet-fake-master
    deepthi adding support for safer DeleteTablet on old masters
* commit https://github.com/vitessio/vitess/commit/35a689b06984bcdb12a8f994db7f14fd52adb5d0, PR https://github.com/vitessio/vitess/pull/5673 from planetscale:consultopo-watch-heartbeat
    makes consultopo watcher not remain stalled after network partition
* commit https://github.com/vitessio/vitess/commit/edb59bdb5fc6bb5a51be92f36b5ff4de50e998fa, PR https://github.com/vitessio/vitess/pull/5815 from tinyspeck/sp-limit-hc-by-keyspace
    serry adding support for limiting topo healthchecks per keyspace
* commit https://github.com/vitessio/vitess/commit/1aeb13eef6dbb001422094f7c46c63135fa74dec, PR https://github.com/vitessio/vitess/pull/5841  from planetscale/ds-prs-new-ctx-for-undo
    deepthi adding a new context for UndoDemoteMaster (which makes failed reparents much safer)
* commit https://github.com/vitessio/vitess/commit/f0797e741b3ff4ba2e655b3e9235c2d11266b928, PR https://github.com/vitessio/vitess/pull/5881 from tinyspeck/sp-log-conn-accept-err
    serry adding tracking of ConnRefused from mysql
* commit https://github.com/vitessio/vitess/commit/aed84eef2b0e16a5ce4750db93e83faf31a89100, PR https://github.com/vitessio/vitess/pull/5894, from tinyspeck:hack-route-replica-to-rdonly-also
   demmer adding union routing for replica/rdonyl 