### PR TITLE
[VITESS-1055/VITESS-1057] LegacySplitClone: VReplicate entire tables instead of keyrange

### DIFF
--- a/go/vt/vtgate/vindexes/lookup.go
+++ b/go/vt/vtgate/vindexes/lookup.go
@@ -273,7 +273,7 @@ func (lu *LookupUnique) String() string {
 
 // Cost returns the cost of this vindex as 1
 func (lu *LookupUnique) Cost() int {
-	// Hardcoding to 1 so we vtworkers don't ignore this vindex
+	// Hardcoding to 1 so vtworkers don't ignore this vindex
 	return 1
 }
 

--- a/go/vt/vtgate/vindexes/lookup.go
+++ b/go/vt/vtgate/vindexes/lookup.go
@@ -271,9 +271,10 @@ func (lu *LookupUnique) String() string {
 	return lu.name
 }
 
-// Cost returns the cost of this vindex as 10.
+// Cost returns the cost of this vindex as 1
 func (lu *LookupUnique) Cost() int {
-	return 10
+	// Hardcoding to 1 so we vtworkers don't ignore this vindex
+	return 1
 }
 
 // IsUnique returns true since the Vindex is unique.

--- a/go/vt/vtgate/vindexes/lookup_unique_test.go
+++ b/go/vt/vtgate/vindexes/lookup_unique_test.go
@@ -97,7 +97,7 @@ func TestLookupUniqueNewHandlesMissingEncoder(t *testing.T) {
 
 func TestLookupUniqueInfo(t *testing.T) {
 	lookupUnique := createLookup(t, "lookup_unique", false)
-	assert.Equal(t, 10, lookupUnique.Cost())
+	assert.Equal(t, 1, lookupUnique.Cost())
 	assert.Equal(t, "lookup_unique", lookupUnique.String())
 	assert.True(t, lookupUnique.IsUnique())
 }

--- a/go/vt/worker/legacy_split_clone.go
+++ b/go/vt/worker/legacy_split_clone.go
@@ -633,8 +633,10 @@ func (scw *LegacySplitCloneWorker) copy(ctx context.Context) error {
 				bls := &binlogdatapb.BinlogSource{
 					Keyspace: src.Keyspace(),
 					Shard:    src.ShardName(),
-					// @bramos: this is meant for a merge so we want to unconditionally replicate
-					// the table to the destination shard
+					// @bramos: Instead of setting up a keyrange to replicate,
+					// we're taking advantage of the fact that we're merging
+					// to unconditionally replicate the entire shard
+					// KeyRange: kr,
 					Tables: tablesToReplicateSlice,
 				}
 				qr, err := exc.vreplicationExec(


### PR DESCRIPTION
## Overview

Instead of setting up vreplication to filter by keyranges, let's set it up to replicate entire tables since we are going to be merging and we want all records in the destination. This should be a safe operation since we'll be validating source shards using out of band scripts. Also, throw in a hardcode of the `LookupUnique` vindex since we need it to [not be ignored by vtworkers](https://github.com/tinyspeck/vitess/blob/aa70055e985bc77692243218f3700f1dc773f240/go/vt/vtgate/vindexes/vschema.go#L673-L675).

## Changes

- In `LegacySplitClone`, collect table names from source shards and construct `BinlogSource` accordingly
- hardcode `LookupUnique` cost

## Testing 
vtworkers build.