### PR TITLE
[legacy_split_clone] Filter out empty table names and uniquify tables for vreplication request

### DIFF
--- a/go/vt/worker/legacy_split_clone.go
+++ b/go/vt/worker/legacy_split_clone.go
@@ -655,7 +655,7 @@ func (scw *LegacySplitCloneWorker) copy(ctx context.Context) error {
 			defer destinationWaitGroup.Done()
 			scw.wr.Logger().Infof("Making and populating vreplication table for %v/%v", keyspace, shard)
 
-			tablesToReplicateSlice := make([]string, len(tablesToReplicateMap))
+			tablesToReplicateSlice := make([]string, 0, len(tablesToReplicateMap))
 			for tn := range tablesToReplicateMap {
 				tablesToReplicateSlice = append(tablesToReplicateSlice, tn)
 			}

--- a/go/vt/worker/legacy_split_clone.go
+++ b/go/vt/worker/legacy_split_clone.go
@@ -485,6 +485,8 @@ func (scw *LegacySplitCloneWorker) copy(ctx context.Context) error {
 
 		if td.Name != "" {
 			tablesToReplicateMap[td.Name] = true
+		} else {
+			scw.wr.Logger().Infof("Found table definition with empty table name: %+v", td)
 		}
 	}
 

--- a/go/vt/worker/legacy_split_clone.go
+++ b/go/vt/worker/legacy_split_clone.go
@@ -477,13 +477,15 @@ func (scw *LegacySplitCloneWorker) copy(ctx context.Context) error {
 		return fmt.Errorf("no tables matching the table filter in tablet %v", topoproto.TabletAliasString(scw.sourceAliases[0]))
 	}
 
-	tablesToReplicateSlice := make([]string, len(sourceSchemaDefinition.TableDefinitions))
+	tablesToReplicateMap := make(map[string]bool)
 	for _, td := range sourceSchemaDefinition.TableDefinitions {
 		if len(td.Columns) == 0 {
 			return fmt.Errorf("schema for table %v has no columns", td.Name)
 		}
 
-		tablesToReplicateSlice = append(tablesToReplicateSlice, td.Name)
+		if td.Name != "" {
+			tablesToReplicateMap[td.Name] = true
+		}
 	}
 
 	scw.wr.Logger().Infof("Source tablet 0 has %v tables to copy", len(sourceSchemaDefinition.TableDefinitions))
@@ -650,6 +652,11 @@ func (scw *LegacySplitCloneWorker) copy(ctx context.Context) error {
 		go func(keyspace, shard string, kr *topodatapb.KeyRange) {
 			defer destinationWaitGroup.Done()
 			scw.wr.Logger().Infof("Making and populating vreplication table for %v/%v", keyspace, shard)
+
+			tablesToReplicateSlice := make([]string, len(tablesToReplicateMap))
+			for tn := range tablesToReplicateMap {
+				tablesToReplicateSlice = append(tablesToReplicateSlice, tn)
+			}
 
 			exc := newExecutor(scw.wr, scw.tsc, nil, keyspace, shard, 0)
 			for shardIndex, src := range scw.sourceShards {


### PR DESCRIPTION
## Description

When testing this in dev, found that the vreplication request setup after the copy step of `LegacySplitClone` would include empty table names. This PR does the more defensive thing of filtering out empty table names and uniquifies them as well

## Changes

- use a map to collect table names and turn into a slice when needed.

## Testing 
- existing unit tests continue to pass/fail
- rolling out to dev to mess around with