### PR TITLE
[vmerge] Add stats to the post merge report

### DIFF
--- a/go/vt/worker/legacy_split_clone.go
+++ b/go/vt/worker/legacy_split_clone.go
@@ -57,7 +57,7 @@ type mergeStatsImpl struct {
 	badRows     int
 }
 
-func (st mergeStatsImpl) dropRows(table string, n int, keys []string) {
+func (st *mergeStatsImpl) dropRows(table string, n int, keys []string) {
 	st.m.Lock()
 	defer st.m.Unlock()
 
@@ -70,7 +70,7 @@ func (st mergeStatsImpl) dropRows(table string, n int, keys []string) {
 	}
 }
 
-func (st mergeStatsImpl) hitBadRows(table string, n int) {
+func (st *mergeStatsImpl) hitBadRows(table string, n int) {
 	st.m.Lock()
 	defer st.m.Unlock()
 	st.badRows += n
@@ -251,10 +251,10 @@ func (scw *LegacySplitCloneWorker) Run(ctx context.Context) error {
 	l.Errorf("  Dropped Keys")
 	for table, keys := range scw.mergeStats.droppedKeys {
 		l.Errorf("    table %v {", table)
-		for _, k := range keys {
-			l.Errorf("      %v", k)
+		for k := range keys {
+			l.Errorf("        %v", k)
 		}
-		l.Errorf("}")
+		l.Errorf("    }")
 	}
 	l.Errorf("  Bad Rows: %v", scw.mergeStats.badRows)
 

--- a/go/vt/worker/legacy_split_clone.go
+++ b/go/vt/worker/legacy_split_clone.go
@@ -63,6 +63,9 @@ func (st mergeStatsImpl) dropRows(table string, n int, keys []string) {
 
 	st.droppedRows += n
 	for _, k := range keys {
+		if _, ok := st.droppedKeys[table]; !ok {
+			st.droppedKeys[table] = map[string]bool{}
+		}
 		st.droppedKeys[table][k] = true
 	}
 }


### PR DESCRIPTION
Tracks how many rows were dropped and which keys got dropped.

Testing -- in dev, validated in success and dropped row cases. Didn't validate the logic around bad rows but it's less pressing since we're currently not planning on continuing in those cases.

We can come back and build out additional tooling there if we want to build some kind bad-key blessing. This change also puts structure in place for that by plumbing the table around.