### PR TITLE
Fix bug in vtgate when running with keyspace filtering

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -148,6 +148,11 @@ func init() {
 	flag.Var(&KeyspacesToWatch, "keyspaces_to_watch", "Specifies which keyspaces this vtgate should have access to while routing queries or accessing the vschema")
 }
 
+// FilteringKeyspaces returns true if any keyspaces have been configured to be filtered.
+func FilteringKeyspaces() bool {
+	return len(KeyspacesToWatch) > 0
+}
+
 // TabletRecorder is a sub interface of HealthCheck.
 // It is separated out to enable unit testing.
 type TabletRecorder interface {

--- a/go/vt/srvtopo/keyspace_filtering_server.go
+++ b/go/vt/srvtopo/keyspace_filtering_server.go
@@ -18,7 +18,6 @@ package srvtopo
 
 import (
 	"fmt"
-	"runtime/debug"
 
 	"golang.org/x/net/context"
 
@@ -67,7 +66,6 @@ type keyspaceFilteringServer struct {
 // GetTopoServer returns an error; filtering srvtopo.Server consumers may not
 // access the underlying topo.Server.
 func (ksf keyspaceFilteringServer) GetTopoServer() (*topo.Server, error) {
-	debug.PrintStack()
 	return nil, ErrTopoServerNotAvailable
 }
 

--- a/go/vt/srvtopo/keyspace_filtering_server.go
+++ b/go/vt/srvtopo/keyspace_filtering_server.go
@@ -18,6 +18,7 @@ package srvtopo
 
 import (
 	"fmt"
+	"runtime/debug"
 
 	"golang.org/x/net/context"
 
@@ -66,6 +67,7 @@ type keyspaceFilteringServer struct {
 // GetTopoServer returns an error; filtering srvtopo.Server consumers may not
 // access the underlying topo.Server.
 func (ksf keyspaceFilteringServer) GetTopoServer() (*topo.Server, error) {
+	debug.PrintStack()
 	return nil, ErrTopoServerNotAvailable
 }
 

--- a/go/vt/vtgate/discoverygateway.go
+++ b/go/vt/vtgate/discoverygateway.go
@@ -131,7 +131,7 @@ func NewDiscoveryGateway(ctx context.Context, hc discovery.LegacyHealthCheck, se
 		}
 		var recorder discovery.LegacyTabletRecorder = dg.hc
 		if len(discovery.TabletFilters) > 0 {
-			if len(discovery.KeyspacesToWatch) > 0 {
+			if discovery.FilteringKeyspaces() {
 				log.Exitf("Only one of -keyspaces_to_watch and -tablet_filters may be specified at a time")
 			}
 
@@ -140,7 +140,7 @@ func NewDiscoveryGateway(ctx context.Context, hc discovery.LegacyHealthCheck, se
 				log.Exitf("Cannot parse tablet_filters parameter: %v", err)
 			}
 			recorder = fbs
-		} else if len(discovery.KeyspacesToWatch) > 0 {
+		} else if discovery.FilteringKeyspaces() {
 			recorder = discovery.NewLegacyFilterByKeyspace(recorder, discovery.KeyspacesToWatch)
 		}
 

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -491,7 +491,7 @@ func (vc *vcursorImpl) TabletType() topodatapb.TabletType {
 // SubmitOnlineDDL implements the VCursor interface
 func (vc *vcursorImpl) SubmitOnlineDDL(onlineDDl *schema.OnlineDDL) error {
 	if vc.topoServer == nil {
-		return vterrors.New(vtrpcpb.Code_INTERNAL, "Unable to apply DDL, missing toposerver in vcursor")
+		return vterrors.New(vtrpcpb.Code_INTERNAL, "Unable to apply DDL toposerver unavailable, ensure this vtgate is not using filtered keyspaces")
 	}
 	conn, err := vc.topoServer.ConnForCell(vc.ctx, topo.GlobalCell)
 	if err != nil {

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -162,8 +162,8 @@ func newVCursorImpl(
 		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "newVCursorImpl: transactions are supported only for master tablet types, current type: %v", tabletType)
 	}
 	var ts *topo.Server
-	// We can't apply DDL if this vtgate is filtering keyspaces because we
-	// don't have an accurate view of the TopoServer
+	// We don't have access to the underlying TopoServer if this vtgate is
+	// filtering keyspaces because we don't have an accurate view of the topo.
 	if serv != nil && !discovery.FilteringKeyspaces() {
 		ts, err = serv.GetTopoServer()
 		if err != nil {

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -156,7 +156,7 @@ func Init(ctx context.Context, serv srvtopo.Server, cell string, tabletTypesToWa
 
 	// If we want to filter keyspaces replace the srvtopo.Server with a
 	// filtering server
-	if len(discovery.KeyspacesToWatch) > 0 {
+	if discovery.FilteringKeyspaces() {
 		log.Infof("Keyspace filtering enabled, selecting %v", discovery.KeyspacesToWatch)
 		var err error
 		serv, err = srvtopo.NewKeyspaceFilteringServer(serv, discovery.KeyspacesToWatch)
@@ -495,7 +495,7 @@ func LegacyInit(ctx context.Context, hc discovery.LegacyHealthCheck, serv srvtop
 
 	// If we want to filter keyspaces replace the srvtopo.Server with a
 	// filtering server
-	if len(discovery.KeyspacesToWatch) > 0 {
+	if discovery.FilteringKeyspaces() {
 		log.Infof("Keyspace filtering enabled, selecting %v", discovery.KeyspacesToWatch)
 		var err error
 		serv, err = srvtopo.NewKeyspaceFilteringServer(serv, discovery.KeyspacesToWatch)


### PR DESCRIPTION
## Description

This checks if a vtgate is currently filtering keyspaces before requesting the TopoServer. This is necessary because a TopoServer can't be accessed in those cases as the filtered Topo in those cases could make it unsafe to make writes since all reads would be returning a subset of the actual topo data.

The only use of the requested topoServer that I found was in the DDL handling path and was introduced in https://github.com/vitessio/vitess/pull/6547.

This is deployed on dev but should get testing (endtoend or unit, unclear on best path atm) before going upstream.