### PR TITLE
[tm_state] updateLocked should re-populate local metadata tables to reflect promotion rule changes

### DIFF
--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -104,6 +104,7 @@ func main() {
 		QueryServiceControl: qsc,
 		UpdateStream:        binlog.NewUpdateStream(ts, tablet.Keyspace, tabletAlias.Cell, qsc.SchemaEngine()),
 		VREngine:            vreplication.NewEngine(config, ts, tabletAlias.Cell, mysqld),
+		MetadataManager:     &mysqlctl.MetadataManager{},
 	}
 	if err := tm.Start(tablet, config.Healthcheck.IntervalSeconds.Get()); err != nil {
 		log.Exitf("failed to parse -tablet-path or initialize DB credentials: %v", err)

--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -94,8 +94,8 @@ var (
 	// statsBackupIsRunning is set to 1 (true) if a backup is running.
 	statsBackupIsRunning *stats.GaugesWithMultiLabels
 
-	// statsIsInSRVKeyspace is set to 1 (true), 0 (false) whether the tablet is in the serving keyspace
-	statsIsInSRVKeyspace *stats.Gauge
+	// statsIsInSrvKeyspace is set to 1 (true), 0 (false) whether the tablet is in the serving keyspace
+	statsIsInSrvKeyspace *stats.Gauge
 
 	statsKeyspace      = stats.NewString("TabletKeyspace")
 	statsShard         = stats.NewString("TabletShard")
@@ -118,7 +118,7 @@ func init() {
 	statsTabletType = stats.NewString("TabletType")
 	statsTabletTypeCount = stats.NewCountersWithSingleLabel("TabletTypeCount", "Number of times the tablet changed to the labeled type", "type")
 	statsBackupIsRunning = stats.NewGaugesWithMultiLabels("BackupIsRunning", "Whether a backup is running", []string{"mode"})
-	statsIsInSRVKeyspace = stats.NewGauge("IsInSRVKeyspace", "Whether the vttablet is in the serving keyspace (1 = true / 0 = false)")
+	statsIsInSrvKeyspace = stats.NewGauge("IsInSRVKeyspace", "Whether the vttablet is in the serving keyspace (1 = true / 0 = false)")
 }
 
 // TabletManager is the main class for the tablet manager.
@@ -132,6 +132,11 @@ type TabletManager struct {
 	QueryServiceControl tabletserver.Controller
 	UpdateStream        binlog.UpdateStreamControl
 	VREngine            *vreplication.Engine
+
+	// MetadataManager manages the local metadata tables for a tablet. It
+	// exists, and is exported, to support swapping a nil pointer in test code,
+	// in which case metadata creation/population is skipped.
+	MetadataManager *mysqlctl.MetadataManager
 
 	// tmState manages the TabletManager state.
 	tmState *tmState
@@ -628,9 +633,12 @@ func (tm *TabletManager) handleRestore(ctx context.Context) (bool, error) {
 				return false, err
 			}
 		}
-		err := mysqlctl.PopulateMetadataTables(tm.MysqlDaemon, localMetadata, topoproto.TabletDbName(tablet))
-		if err != nil {
-			return false, vterrors.Wrap(err, "failed to -init_populate_metadata")
+
+		if tm.MetadataManager != nil {
+			err := tm.MetadataManager.PopulateMetadataTables(tm.MysqlDaemon, localMetadata, topoproto.TabletDbName(tablet))
+			if err != nil {
+				return false, vterrors.Wrap(err, "failed to -init_populate_metadata")
+			}
 		}
 	}
 	return false, nil

--- a/go/vt/vttablet/tabletmanager/tm_init_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_init_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/mysql/fakesqldb"
+	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/logutil"
@@ -333,7 +335,7 @@ func TestStartCheckMysql(t *testing.T) {
 	tm := &TabletManager{
 		BatchCtx:            context.Background(),
 		TopoServer:          ts,
-		MysqlDaemon:         &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: sync2.NewAtomicInt32(-1)},
+		MysqlDaemon:         newTestMysqlDaemon(t, 1),
 		DBConfigs:           dbconfigs.NewTestDBConfigs(cp, cp, ""),
 		QueryServiceControl: tabletservermock.NewController(),
 	}
@@ -355,7 +357,7 @@ func TestStartFindMysqlPort(t *testing.T) {
 	cell := "cell1"
 	ts := memorytopo.NewServer(cell)
 	tablet := newTestTablet(t, 1, "ks", "0")
-	fmd := &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: sync2.NewAtomicInt32(-1)}
+	fmd := newTestMysqlDaemon(t, -1)
 	tm := &TabletManager{
 		BatchCtx:            context.Background(),
 		TopoServer:          ts,
@@ -502,6 +504,33 @@ func TestCheckTabletTypeResets(t *testing.T) {
 	tm.Stop()
 }
 
+func newTestMysqlDaemon(t *testing.T, port int32) *fakemysqldaemon.FakeMysqlDaemon {
+	t.Helper()
+
+	db := fakesqldb.New(t)
+	db.AddQueryPattern("SET @@.*", &sqltypes.Result{})
+	db.AddQueryPattern("BEGIN", &sqltypes.Result{})
+	db.AddQueryPattern("COMMIT", &sqltypes.Result{})
+
+	db.AddQueryPattern("CREATE DATABASE IF NOT EXISTS _vt", &sqltypes.Result{})
+	db.AddQueryPattern("CREATE TABLE IF NOT EXISTS _vt\\.(local|shard)_metadata.*", &sqltypes.Result{})
+
+	db.AddQueryPattern("ALTER TABLE _vt\\.local_metadata ADD COLUMN (db_name).*", &sqltypes.Result{})
+	db.AddQueryPattern("ALTER TABLE _vt\\.local_metadata DROP PRIMARY KEY, ADD PRIMARY KEY\\(name, db_name\\)", &sqltypes.Result{})
+	db.AddQueryPattern("ALTER TABLE _vt\\.local_metadata CHANGE value.*", &sqltypes.Result{})
+
+	db.AddQueryPattern("ALTER TABLE _vt\\.shard_metadata ADD COLUMN (db_name).*", &sqltypes.Result{})
+	db.AddQueryPattern("ALTER TABLE _vt\\.shard_metadata DROP PRIMARY KEY, ADD PRIMARY KEY\\(name, db_name\\)", &sqltypes.Result{})
+
+	db.AddQueryPattern("UPDATE _vt\\.(local|shard)_metadata SET db_name='.+' WHERE db_name=''", &sqltypes.Result{})
+	db.AddQueryPattern("INSERT INTO _vt\\.local_metadata \\(.+\\) VALUES \\(.+\\) ON DUPLICATE KEY UPDATE value ?= ?'.+'.*", &sqltypes.Result{})
+
+	mysqld := fakemysqldaemon.NewFakeMysqlDaemon(db)
+	mysqld.MysqlPort = sync2.NewAtomicInt32(port)
+
+	return mysqld
+}
+
 func newTestTM(t *testing.T, ts *topo.Server, uid int, keyspace, shard string) *TabletManager {
 	t.Helper()
 	ctx := context.Background()
@@ -509,7 +538,7 @@ func newTestTM(t *testing.T, ts *topo.Server, uid int, keyspace, shard string) *
 	tm := &TabletManager{
 		BatchCtx:            ctx,
 		TopoServer:          ts,
-		MysqlDaemon:         &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: sync2.NewAtomicInt32(1)},
+		MysqlDaemon:         newTestMysqlDaemon(t, 1),
 		DBConfigs:           &dbconfigs.DBConfigs{},
 		QueryServiceControl: tabletservermock.NewController(),
 	}

--- a/go/vt/vttablet/tabletmanager/tm_state_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_state_test.go
@@ -152,7 +152,7 @@ func TestStateTabletControls(t *testing.T) {
 	assert.False(t, qsc.IsServing())
 }
 
-func TestStateIsShardServingisInSRVKeyspace(t *testing.T) {
+func TestStateIsShardServingisInSrvKeyspace(t *testing.T) {
 	ctx := context.Background()
 	ts := memorytopo.NewServer("cell1")
 	tm := newTestTM(t, ts, 1, "ks", "0")
@@ -160,6 +160,7 @@ func TestStateIsShardServingisInSRVKeyspace(t *testing.T) {
 
 	tm.tmState.mu.Lock()
 	tm.tmState.tablet.Type = topodatapb.TabletType_MASTER
+	tm.tmState.updateLocked(ctx)
 	tm.tmState.mu.Unlock()
 
 	leftKeyRange, err := key.ParseShardingSpec("-80")
@@ -199,11 +200,11 @@ func TestStateIsShardServingisInSRVKeyspace(t *testing.T) {
 	tm.tmState.RefreshFromTopoInfo(ctx, nil, ks)
 
 	tm.tmState.mu.Lock()
-	assert.False(t, tm.tmState.isInSRVKeyspace)
+	assert.False(t, tm.tmState.isInSrvKeyspace)
 	assert.Equal(t, want, tm.tmState.isShardServing)
 	tm.tmState.mu.Unlock()
 
-	assert.Equal(t, int64(0), statsIsInSRVKeyspace.Get())
+	assert.Equal(t, int64(0), statsIsInSrvKeyspace.Get())
 
 	// Shard not in the SrvKeyspace, ServedType in SrvKeyspace
 	ks = &topodatapb.SrvKeyspace{
@@ -227,11 +228,11 @@ func TestStateIsShardServingisInSRVKeyspace(t *testing.T) {
 	tm.tmState.RefreshFromTopoInfo(ctx, nil, ks)
 
 	tm.tmState.mu.Lock()
-	assert.False(t, tm.tmState.isInSRVKeyspace)
+	assert.False(t, tm.tmState.isInSrvKeyspace)
 	assert.Equal(t, want, tm.tmState.isShardServing)
 	tm.tmState.mu.Unlock()
 
-	assert.Equal(t, int64(0), statsIsInSRVKeyspace.Get())
+	assert.Equal(t, int64(0), statsIsInSrvKeyspace.Get())
 
 	// Shard in the SrvKeyspace, ServedType in the SrvKeyspace
 	ks = &topodatapb.SrvKeyspace{
@@ -253,11 +254,11 @@ func TestStateIsShardServingisInSRVKeyspace(t *testing.T) {
 	tm.tmState.RefreshFromTopoInfo(ctx, nil, ks)
 
 	tm.tmState.mu.Lock()
-	assert.True(t, tm.tmState.isInSRVKeyspace)
+	assert.True(t, tm.tmState.isInSrvKeyspace)
 	assert.Equal(t, want, tm.tmState.isShardServing)
 	tm.tmState.mu.Unlock()
 
-	assert.Equal(t, int64(1), statsIsInSRVKeyspace.Get())
+	assert.Equal(t, int64(1), statsIsInSrvKeyspace.Get())
 
 	// Shard in the SrvKeyspace, ServedType not in the SrvKeyspace
 	ks = &topodatapb.SrvKeyspace{
@@ -279,29 +280,29 @@ func TestStateIsShardServingisInSRVKeyspace(t *testing.T) {
 	tm.tmState.RefreshFromTopoInfo(ctx, nil, ks)
 
 	tm.tmState.mu.Lock()
-	assert.False(t, tm.tmState.isInSRVKeyspace)
+	assert.False(t, tm.tmState.isInSrvKeyspace)
 	assert.Equal(t, want, tm.tmState.isShardServing)
 	tm.tmState.mu.Unlock()
 
-	assert.Equal(t, int64(0), statsIsInSRVKeyspace.Get())
+	assert.Equal(t, int64(0), statsIsInSrvKeyspace.Get())
 
 	// Test tablet type change - shard in the SrvKeyspace, ServedType in the SrvKeyspace
 	err = tm.tmState.ChangeTabletType(ctx, topodatapb.TabletType_RDONLY, DBActionNone)
 	require.NoError(t, err)
 	tm.tmState.mu.Lock()
-	assert.True(t, tm.tmState.isInSRVKeyspace)
+	assert.True(t, tm.tmState.isInSrvKeyspace)
 	tm.tmState.mu.Unlock()
 
-	assert.Equal(t, int64(1), statsIsInSRVKeyspace.Get())
+	assert.Equal(t, int64(1), statsIsInSrvKeyspace.Get())
 
 	// Test tablet type change - shard in the SrvKeyspace, ServedType in the SrvKeyspace
 	err = tm.tmState.ChangeTabletType(ctx, topodatapb.TabletType_DRAINED, DBActionNone)
 	require.NoError(t, err)
 	tm.tmState.mu.Lock()
-	assert.False(t, tm.tmState.isInSRVKeyspace)
+	assert.False(t, tm.tmState.isInSrvKeyspace)
 	tm.tmState.mu.Unlock()
 
-	assert.Equal(t, int64(0), statsIsInSRVKeyspace.Get())
+	assert.Equal(t, int64(0), statsIsInSrvKeyspace.Get())
 }
 
 func TestStateNonServing(t *testing.T) {


### PR DESCRIPTION
This cherry-picks a squashed version of https://github.com/vitessio/vitess/pull/8107 into our master branch

Signed-off-by: Andrew Mason <amason@slack-corp.com>

Defer populating metadata to handle different queryservice states

If we're enabling the queryservice, wait until afterwards to populate
the metadata. On the other hand, if we're disabling the queryservice,
then populate the metadata just before shutting down the queryservice.

Signed-off-by: Andrew Mason <amason@slack-corp.com>

Update testTM mysqldaemon to support local_metadata queries

Signed-off-by: Andrew Mason <amason@slack-corp.com>

Add missing `updateLocked` call on tablettype change in test

Signed-off-by: Andrew Mason <amason@slack-corp.com>

Track whether tm_state is opening, and try to respect the `init_populate_metadata` flag

Signed-off-by: Andrew Mason <amason@slack-corp.com>

Separate metadata table creation from upserting

Signed-off-by: Andrew Mason <amason@slack-corp.com>

Add a MetadataManager to replace the TabletManager.LocalMetadataPopulator func

Also, track if we've previously called PopulateMetadataTables, and if
so, only do the Upsert rather than Create+Upsert

Signed-off-by: Andrew Mason <amason@slack-corp.com>

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

## Related Issue(s)
<!-- List related issues and pull requests: -->

- 

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build 
