### PR TITLE
Makes ReplicationStatus.IOThreadRunning more strict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,5 @@ venv
 
 .scannerwork
 report
+
+vendor

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -135,7 +135,11 @@ func (mysqlFlavor) status(c *Conn) (ReplicationStatus, error) {
 		return ReplicationStatus{}, err
 	}
 
-	log.V(1).Infof("debug: SHOW SLAVE STATUS=%+v",resultMap)
+	if log.V(1) {
+		for k, v := range resultMap {
+			log.Infof("debug: SHOW SLAVE STATUS resultMap.%s: %s", k, v)
+		}
+	}
 	return parseMysqlReplicationStatus(resultMap)
 }
 

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -17,12 +17,12 @@ limitations under the License.
 package mysql
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"time"
 
-	"context"
-
+	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 )
@@ -135,6 +135,7 @@ func (mysqlFlavor) status(c *Conn) (ReplicationStatus, error) {
 		return ReplicationStatus{}, err
 	}
 
+	log.V(1).Infof("debug: SHOW SLAVE STATUS=%+v",resultMap)
 	return parseMysqlReplicationStatus(resultMap)
 }
 

--- a/go/mysql/replication_status.go
+++ b/go/mysql/replication_status.go
@@ -19,6 +19,7 @@ package mysql
 import (
 	"fmt"
 
+	"vitess.io/vitess/go/vt/log"
 	replicationdatapb "vitess.io/vitess/go/vt/proto/replicationdata"
 	"vitess.io/vitess/go/vt/vterrors"
 )
@@ -46,6 +47,7 @@ type ReplicationStatus struct {
 // ReplicationRunning returns true iff both the IO and SQL threads are
 // running.
 func (s *ReplicationStatus) ReplicationRunning() bool {
+	log.V(1).Infof("debug: ReplicationStatus=%+v",s)
 	return s.IOThreadRunning && s.SQLThreadRunning
 }
 

--- a/go/mysql/replication_status.go
+++ b/go/mysql/replication_status.go
@@ -47,7 +47,7 @@ type ReplicationStatus struct {
 // ReplicationRunning returns true iff both the IO and SQL threads are
 // running.
 func (s *ReplicationStatus) ReplicationRunning() bool {
-	log.V(1).Infof("debug: ReplicationStatus=%+v",s)
+	log.V(1).Infof("debug: ReplicationStatus=%+v", s)
 	return s.IOThreadRunning && s.SQLThreadRunning
 }
 


### PR DESCRIPTION
<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
This PR makes ReplicationStatus.IOThreadRunning bool flag more strict by discarding an OR for `Slave_IO_Running == "Connecting"`.

## Related Issue(s)
<!-- List related issues and pull requests: -->
-  https://jira.tinyspeck.com/browse/DRE-6901

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [x] VTTablet