### PR TITLE
implements sanitizeRequestHeader

### DIFF
--- a/go/vt/workflow/long_polling.go
+++ b/go/vt/workflow/long_polling.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/timer"
 	"vitess.io/vitess/go/vt/log"
@@ -159,7 +160,7 @@ func getID(url, base string) (int, error) {
 
 const (
 	LogLevelDumpAllHTTPHeaders glog.Level = 50
-	HTTPHeaderRedactedMessage             = "*** redacted by sanitizeRequestHeader() ***"
+	HTTPHeaderRedactedMessage  string     = "*** redacted by sanitizeRequestHeader() ***"
 )
 
 var whiteListedHTTPHeaders = map[string]interface{}{

--- a/go/vt/workflow/long_polling.go
+++ b/go/vt/workflow/long_polling.go
@@ -175,7 +175,7 @@ var whiteListedHTTPHeaders = map[string]interface{}{
 	"X-Real-Ip":                 nil,
 }
 
-// sanitizeRequestHeader - makes a copy of r and returns a copy with sanitized headers unless debugOn=true
+// sanitizeRequestHeader - (unless debugOn=true) makes a copy of r and returns it with sanitized headers
 func sanitizeRequestHeader(r *http.Request, debugOn bool) *http.Request {
 	if debugOn {
 		return r

--- a/go/vt/workflow/long_polling.go
+++ b/go/vt/workflow/long_polling.go
@@ -17,6 +17,7 @@ limitations under the License.
 package workflow
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -27,8 +28,7 @@ import (
 	"sync"
 	"time"
 
-	"context"
-
+	"github.com/golang/glog"
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/timer"
 	"vitess.io/vitess/go/vt/log"
@@ -157,9 +157,48 @@ func getID(url, base string) (int, error) {
 	return i, nil
 }
 
+const (
+	LogLevelDumpAllHTTPHeaders glog.Level = 50
+	HTTPHeaderRedactedMessage             = "*** redacted by sanitizeRequestHeader() ***"
+)
+
+var whiteListedHTTPHeaders = map[string]interface{}{
+	"Accept":                    nil,
+	"Accept-Encoding":           nil,
+	"Accept-Language":           nil,
+	"Upgrade-Insecure-Requests": nil,
+	"User-Agent":                nil,
+	"X-Forwarded-For":           nil,
+	"X-Forwarded-Host":          nil,
+	"X-Forwarded-Proto":         nil,
+	"X-Real-Ip":                 nil,
+}
+
+// sanitizeRequestHeader - makes a copy of r and returns a copy with sanitized headers unless debugOn=true
+func sanitizeRequestHeader(r *http.Request, debugOn bool) *http.Request {
+	if debugOn {
+		return r
+	}
+
+	s := r.Clone(r.Context())
+
+	for k := range s.Header {
+		if _, ok := whiteListedHTTPHeaders[k]; !ok {
+			s.Header.Set(k, HTTPHeaderRedactedMessage)
+		}
+	}
+
+	return s
+}
+
 func httpErrorf(w http.ResponseWriter, r *http.Request, format string, args ...interface{}) {
 	errMsg := fmt.Sprintf(format, args...)
-	log.Errorf("HTTP error on %v: %v, request: %#v", r.URL.Path, errMsg, r)
+	debugOn := bool(log.V(LogLevelDumpAllHTTPHeaders))
+	log.Errorf("HTTP error on %v: %v, request: %#v",
+		r.URL.Path,
+		errMsg,
+		sanitizeRequestHeader(r, debugOn),
+	)
 	http.Error(w, errMsg, http.StatusInternalServerError)
 }
 

--- a/go/vt/workflow/long_polling_test.go
+++ b/go/vt/workflow/long_polling_test.go
@@ -18,10 +18,12 @@ package workflow
 
 import (
 	"bytes"
+	"context"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -131,4 +133,88 @@ func TestLongPolling(t *testing.T) {
 	// Stop the manager.
 	cancel()
 	wg.Wait()
+}
+
+func TestSanitizeRequestHeaderCookie(t *testing.T) {
+	testCases := []struct {
+		name       string
+		debugOn    bool
+		reqMethod  string
+		reqURL     string
+		reqHeader  map[string]string
+		wantHeader http.Header
+	}{
+		{
+			name:      "withCookie-no-Debug",
+			debugOn:   false,
+			reqMethod: "GET",
+			reqURL:    "https://vtctld-dev-xyz.company.com/api/workflow/poll/11",
+			reqHeader: map[string]string{
+				"Accept":     "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp",
+				"Cookie":     "_ga=GA1.2.1234567899.1234567890; machine-cookie=username:123456789:1234f999ff99aa1af3ae9999d2a5d3968ac014a0947ae1418b10642ab2cbb7d3; session=7e5dc76807be39dd0886b9425883dabe3fd2432f7415e2a08fba7ca43ac4d0dc;",
+				"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36",
+			},
+			wantHeader: map[string][]string{
+				"Accept":     {"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp"},
+				"Cookie":     {HTTPHeaderRedactedMessage},
+				"User-Agent": {"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36"},
+			},
+		},
+		{
+			name:      "withCookie-with-Debug",
+			debugOn:   true,
+			reqMethod: "GET",
+			reqURL:    "https://vtctld-dev-xyz.company.com/api/workflow/poll/11",
+			reqHeader: map[string]string{
+				"Accept":     "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp",
+				"Cookie":     "_ga=GA1.2.1234567899.1234567890; machine-cookie=username:123456789:1234f999ff99aa1af3ae9999d2a5d3968ac014a0947ae1418b10642ab2cbb7d3; session=7e5dc76807be39dd0886b9425883dabe3fd2432f7415e2a08fba7ca43ac4d0dc;",
+				"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36",
+			},
+			wantHeader: map[string][]string{
+				"Accept":     {"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp"},
+				"Cookie":     {"_ga=GA1.2.1234567899.1234567890; machine-cookie=username:123456789:1234f999ff99aa1af3ae9999d2a5d3968ac014a0947ae1418b10642ab2cbb7d3; session=7e5dc76807be39dd0886b9425883dabe3fd2432f7415e2a08fba7ca43ac4d0dc;"},
+				"User-Agent": {"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36"},
+			},
+		},
+		{
+			name:      "noCookie-no-Debug",
+			debugOn:   false,
+			reqMethod: "GET",
+			reqURL:    "https://vtctld-dev-xyz.company.com/api/workflow/poll/11",
+			reqHeader: map[string]string{
+				"Accept":     "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp",
+				"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36",
+			},
+			wantHeader: map[string][]string{
+				"Accept":     {"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp"},
+				"User-Agent": {"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			req, err := http.NewRequestWithContext(ctx, tc.reqMethod, tc.reqURL, nil)
+			if err != nil {
+				t.Fatalf("can't parse test http req: %v", err)
+			}
+
+			for k, v := range tc.reqHeader {
+				req.Header.Set(k, v)
+			}
+			clone := req.Clone(ctx)
+
+			if got := sanitizeRequestHeader(req, tc.debugOn); !reflect.DeepEqual(got.Header, tc.wantHeader) {
+				t.Errorf("sanitizeRequestHeader() failed\nwant: %#v\ngot: %#v", tc.wantHeader, got.Header)
+			}
+
+			if !reflect.DeepEqual(clone, req) {
+				t.Errorf("sanitizeRequestHeader() corrupted original http request\nwant: %#v\ngot: %#v", clone, req)
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR fixes vtctld logging which is currently leaking http header values that can contain PII.

## Related Issue(s)
<!-- List related issues and pull requests: -->
- https://jira.tinyspeck.com/browse/DRE-6017
- https://github.com/vitessio/vitess/issues/8277

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [x]  Vtctld
