### PR TITLE
Slack vitess v11.0.4.pre.v2 (reverts backup: Use pargzip instead of pgzip for compression)

### DIFF
--- a/.github/workflows/cluster_endtoend_11.yml
+++ b/.github/workflows/cluster_endtoend_11.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (11)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (12)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (13)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_14.yml
+++ b/.github/workflows/cluster_endtoend_14.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (14)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (15)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_16.yml
+++ b/.github/workflows/cluster_endtoend_16.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (16)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (17)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (18)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Installing zookeeper and consul
       run: |

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (19)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (20)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (21)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (22)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_23.yml
+++ b/.github/workflows/cluster_endtoend_23.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (23)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (24)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Installing zookeeper and consul
       run: |

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (26)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (mysql80)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -48,11 +57,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (onlineddl_declarative)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (onlineddl_ghost)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (onlineddl_revert)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (onlineddl_singleton)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (onlineddl_vrepl)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (onlineddl_vrepl_stress)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (onlineddl_vrepl_suite)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (resharding)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (resharding_bytes)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (tabletmanager_tablegc)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (tabletmanager_throttler)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (tabletmanager_throttler_custom_config)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vreplication_basic)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vreplication_cellalias)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vreplication_migrate)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vreplication_multicell)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vreplication_v2)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_vtgate_buffer.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_buffer.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_buffer)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_concurrentdml)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_gen4)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_readafterwrite)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_reservedconn)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_schema)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_topo)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_transaction)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_unsharded)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_vtgate_vindex.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_vindex)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtgate_vschema)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (vtorc)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -2,6 +2,15 @@
 
 name: Cluster (xb_recovery)
 on: [push, pull_request]
+
+env:
+
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+
 jobs:
 
   build:
@@ -43,11 +52,17 @@ jobs:
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
     - name: Run cluster endtoend test
       timeout-minutes: 30

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,6 @@ require (
 	github.com/philhofer/fwd v1.0.0 // indirect
 	github.com/pires/go-proxyproto v0.0.0-20191211124218-517ecdf5bb2b
 	github.com/pkg/errors v0.9.1
-	github.com/planetscale/pargzip v0.0.0-20201116224723-90c7fc03ea8a
 	github.com/planetscale/tengo v0.9.6-ps.v4
 	github.com/planetscale/vtprotobuf v0.0.0-20210521163914-5a02622d1e2a
 	github.com/prometheus/client_golang v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -603,8 +603,6 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/planetscale/pargzip v0.0.0-20201116224723-90c7fc03ea8a h1:y0OpQ4+5tKxeh9+H+2cVgASl9yMZYV9CILinKOiKafA=
-github.com/planetscale/pargzip v0.0.0-20201116224723-90c7fc03ea8a/go.mod h1:GJFUzQuXIoB2Kjn1ZfDhJr/42D5nWOqRcIQVgCxTuIE=
 github.com/planetscale/tengo v0.9.6-ps.v4 h1:nLGFobPtYEZDmuRww38RJiP7gVWVLBMzpTUysLIUF7Q=
 github.com/planetscale/tengo v0.9.6-ps.v4/go.mod h1:Xwj7BHMQW30k479dZvWIl/WOCy33skXRjYZLsKgAINM=
 github.com/planetscale/vtprotobuf v0.0.0-20210521163914-5a02622d1e2a h1:qr27Mt+/BoONcc6hogjN5PPCykCxXvJMpXCtYMMgkws=

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/klauspost/pgzip"
-	"github.com/planetscale/pargzip"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sync2"
@@ -409,12 +408,13 @@ func (be *BuiltinBackupEngine) backupFile(ctx context.Context, params BackupPara
 	}
 
 	// Create the gzip compression pipe, if necessary.
-	var gzip *pargzip.Writer
+	var gzip *pgzip.Writer
 	if *backupStorageCompress {
-		gzip = pargzip.NewWriter(writer)
-		gzip.ChunkSize = *backupCompressBlockSize
-		gzip.Parallel = *backupCompressBlocks
-		gzip.CompressionLevel = pargzip.BestSpeed
+		gzip, err = pgzip.NewWriterLevel(writer, pgzip.BestSpeed)
+		if err != nil {
+			return vterrors.Wrap(err, "cannot create gziper")
+		}
+		gzip.SetConcurrency(*backupCompressBlockSize, *backupCompressBlocks)
 		writer = gzip
 	}
 

--- a/go/vt/mysqlctl/xtrabackupengine.go
+++ b/go/vt/mysqlctl/xtrabackupengine.go
@@ -320,6 +320,7 @@ func (be *XtrabackupEngine) backupFiles(ctx context.Context, params BackupParams
 				capture = true
 			}
 			fmt.Fprintln(posBuilder, line)
+			fmt.Fprintln(stderrBuilder, line)
 		}
 		if err := scanner.Err(); err != nil {
 			params.Logger.Errorf("error reading from xtrabackup stderr: %v", err)

--- a/go/vt/mysqlctl/xtrabackupengine.go
+++ b/go/vt/mysqlctl/xtrabackupengine.go
@@ -32,7 +32,6 @@ import (
 	"time"
 
 	"github.com/klauspost/pgzip"
-	"github.com/planetscale/pargzip"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/logutil"
@@ -271,7 +270,7 @@ func (be *XtrabackupEngine) backupFiles(ctx context.Context, params BackupParams
 
 	destWriters := []io.Writer{}
 	destBuffers := []*bufio.Writer{}
-	destCompressors := []io.WriteCloser{}
+	destCompressors := []*pgzip.Writer{}
 	for _, file := range destFiles {
 		buffer := bufio.NewWriterSize(file, writerBufferSize)
 		destBuffers = append(destBuffers, buffer)
@@ -279,10 +278,11 @@ func (be *XtrabackupEngine) backupFiles(ctx context.Context, params BackupParams
 
 		// Create the gzip compression pipe, if necessary.
 		if *backupStorageCompress {
-			compressor := pargzip.NewWriter(writer)
-			compressor.ChunkSize = *backupCompressBlockSize
-			compressor.Parallel = *backupCompressBlocks
-			compressor.CompressionLevel = pargzip.BestSpeed
+			compressor, err := pgzip.NewWriterLevel(writer, pgzip.BestSpeed)
+			if err != nil {
+				return replicationPosition, vterrors.Wrap(err, "cannot create gzip compressor")
+			}
+			compressor.SetConcurrency(*backupCompressBlockSize, *backupCompressBlocks)
 			writer = compressor
 			destCompressors = append(destCompressors, compressor)
 		}
@@ -522,7 +522,7 @@ func (be *XtrabackupEngine) extractFiles(ctx context.Context, logger logutil.Log
 	}()
 
 	srcReaders := []io.Reader{}
-	srcDecompressors := []io.ReadCloser{}
+	srcDecompressors := []*pgzip.Reader{}
 	for _, file := range srcFiles {
 		reader := io.Reader(file)
 
@@ -736,7 +736,7 @@ func copyToStripes(writers []io.Writer, reader io.Reader, blockSize int64) (writ
 	}
 
 	// Read blocks from source and round-robin them to destination writers.
-	// Since we put a buffer in front of the destination file, and pargzip has its
+	// Since we put a buffer in front of the destination file, and pgzip has its
 	// own buffer as well, we are writing into a buffer either way (whether a
 	// compressor is in the chain or not). That means these writes should not
 	// block often, so we shouldn't need separate goroutines here.

--- a/go/vt/mysqlctl/xtrabackupengine.go
+++ b/go/vt/mysqlctl/xtrabackupengine.go
@@ -308,6 +308,7 @@ func (be *XtrabackupEngine) backupFiles(ctx context.Context, params BackupParams
 		capture := false
 		for scanner.Scan() {
 			line := scanner.Text()
+			fmt.Fprintln(stderrBuilder, line)
 			params.Logger.Infof("xtrabackup stderr: %s", line)
 
 			// Wait until we see the first line of the binlog position.
@@ -320,7 +321,6 @@ func (be *XtrabackupEngine) backupFiles(ctx context.Context, params BackupParams
 				capture = true
 			}
 			fmt.Fprintln(posBuilder, line)
-			fmt.Fprintln(stderrBuilder, line)
 		}
 		if err := scanner.Err(); err != nil {
 			params.Logger.Errorf("error reading from xtrabackup stderr: %v", err)

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -1,5 +1,15 @@
 name: {{.Name}}
 on: [push, pull_request]
+
+env:
+{{if .InstallXtraBackup}}
+  # This is used if we need to pin the xtrabackup version used in tests.
+  # Doing so here because 2.4.25 crashes in our 5.7 tests. See:
+  #   https://jira.percona.com/browse/PXB-2756
+  # If this is NOT set then the latest version available will be used.
+  XTRABACKUP_VERSION: "2.4.24-1"
+{{end}}
+
 jobs:
 
   build:
@@ -52,11 +62,17 @@ jobs:
 
         {{if .InstallXtraBackup}}
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        wget "https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo dpkg -i "percona-release_latest.$(lsb_release -sc)_all.deb"
         sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
+        if [[ -n $XTRABACKUP_VERSION ]]; then
+          debfile="percona-xtrabackup-24_$XTRABACKUP_VERSION.$(lsb_release -sc)_amd64.deb"
+          wget "https://repo.percona.com/pxb-24/apt/pool/main/p/percona-xtrabackup-24/$debfile"
+          sudo apt install -y "./$debfile"
+        else
+          sudo apt-get install -y percona-xtrabackup-24
+        fi
 
         {{end}}
 


### PR DESCRIPTION
This reverts commit d2f2d09f032c81d38a2b93d204c9685b721b7bd4.

Signed-off-by: Rafael Chacon <rafael@slack-corp.com>
Signed-off-by: Vitaliy Mogilevskiy <vmogilevskiy@slack-corp.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Slack vitess v11.0.4.pre.v2 (reverts backup: Use pargzip instead of pgzip for compression)
ref: https://slack-pde.slack.com/archives/CQGR39RA5/p1650968513818269?thread_ts=1650911155.662419&cid=CQGR39RA5

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->