### PR TITLE
[tablet] Split health_check_interval into two flags

### DIFF
--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -106,7 +106,7 @@ func main() {
 		VREngine:            vreplication.NewEngine(config, ts, tabletAlias.Cell, mysqld, qsc.LagThrottler()),
 		MetadataManager:     &mysqlctl.MetadataManager{},
 	}
-	if err := tm.Start(tablet, config.Healthcheck.IntervalSeconds.Get()); err != nil {
+	if err := tm.Start(tablet, config.Healthcheck.ReplicationIntervalSeconds.Get()); err != nil {
 		log.Exitf("failed to parse -tablet-path or initialize DB credentials: %v", err)
 	}
 	servenv.OnClose(func() {

--- a/go/vt/vttablet/tabletserver/tabletenv/config_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config_test.go
@@ -117,6 +117,7 @@ gracePeriods: {}
 healthcheck:
   degradedThresholdSeconds: 30
   intervalSeconds: 20
+  replicationIntervalSeconds: 20
   unhealthyThresholdSeconds: 7200
 hotRowProtection:
   maxConcurrency: 5
@@ -226,6 +227,7 @@ func TestFlags(t *testing.T) {
 	want.HotRowProtection.Mode = Disable
 	want.Consolidator = Enable
 	want.Healthcheck.IntervalSeconds = 20
+	want.Healthcheck.ReplicationIntervalSeconds = 20
 	want.Healthcheck.DegradedThresholdSeconds = 30
 	want.Healthcheck.UnhealthyThresholdSeconds = 7200
 	want.ReplicationTracker.HeartbeatIntervalSeconds = 1
@@ -309,9 +311,12 @@ func TestFlags(t *testing.T) {
 	assert.Equal(t, want, currentConfig)
 
 	healthCheckInterval = 1 * time.Second
+	replicationHealthCheckInterval = 2 * time.Second
 	currentConfig.Healthcheck.IntervalSeconds = 0
+	currentConfig.Healthcheck.ReplicationIntervalSeconds = 0
 	Init()
 	want.Healthcheck.IntervalSeconds = 1
+	want.Healthcheck.ReplicationIntervalSeconds = 2
 	assert.Equal(t, want, currentConfig)
 
 	degradedThreshold = 2 * time.Second

--- a/go/vt/vttablet/tabletserver/tabletenv/config_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config_test.go
@@ -316,7 +316,7 @@ func TestFlags(t *testing.T) {
 	currentConfig.Healthcheck.ReplicationIntervalSeconds = 0
 	Init()
 	want.Healthcheck.IntervalSeconds = 1
-	want.Healthcheck.ReplicationIntervalSeconds = 2
+	want.Healthcheck.ReplicationIntervalSeconds = 1
 	assert.Equal(t, want, currentConfig)
 
 	degradedThreshold = 2 * time.Second


### PR DESCRIPTION
## Description
The health_check_interval flag controls:
- how often we send healthchecks to vtgates via the healthcheck stream
- how often the replication manager checks the health of its replication stream

we'd like to change the first without affecting the other so this PR:
- introduces the `replication_health_check_interval` for the latter
- defaults the resolved config value to the same value as the passed in `health_check_interval` if the new flag is not provided
- passed the new flag value into the `TabletManager` for use in constructing its `replManager`

## Checklist
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

